### PR TITLE
add wayland copy-paste

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,7 +16,6 @@ pub mod logo;
 
 use crate::format;
 use crate::render;
-use copypasta::{ClipboardContext, ClipboardProvider};
 use parking_lot::RwLock;
 use std::cell::{RefCell, RefMut};
 use std::rc::{Rc, Weak};
@@ -1619,12 +1618,10 @@ impl UIElement for TextBox {
                 }
                 self.submit_funcs.append(&mut temp);
             }
-            (VirtualKeyCode::V, true) => {
-                if ctrl_pressed {
-                    let mut clipboard: ClipboardContext = ClipboardContext::new().unwrap();
-                    if let Ok(text) = clipboard.get_contents() {
-                        self.input.push_str(&text)
-                    }
+            (VirtualKeyCode::V, true) if ctrl_pressed => {
+                let mut clipboard = game.clipboard_provider.write();
+                if let Ok(text) = clipboard.get_contents() {
+                    self.input.push_str(&text)
                 }
             }
             _ => {}


### PR DESCRIPTION
Still missing the creating of normal clipboard

https://github.com/alacritty/alacritty/blob/master/alacritty/src/clipboard.rs
```rust
    #[cfg(all(feature = "wayland", not(any(target_os = "macos", windows))))]
    pub unsafe fn new(display: Option<*mut c_void>) -> Self {
        match display {
            Some(display) => {
                let (selection, clipboard) =
                    wayland_clipboard::create_clipboards_from_external(display);
                Self { clipboard: Box::new(clipboard), selection: Some(Box::new(selection)) }
            },
            None => Self::default(),
        }
    }
```
  do something like this to to have it runtime independent, if the project is compiled with winit Wayland support. winit default features is both Wayland, X11. 
  
  I am still learning about rust `#[cfg(any(target_os = "macos", windows))] `
    
     