### PR TITLE
Be compliant with the XDG Base Directory specification on Linux

### DIFF
--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::paths;
+
 use std::any::Any;
 use std::cell::{Ref, RefCell};
 use std::collections::HashMap;
@@ -179,7 +181,7 @@ impl Vars {
     }
 
     pub fn load_config(&mut self) {
-        if let Ok(file) = fs::File::open("conf.cfg") {
+        if let Ok(file) = fs::File::open(paths::get_config_dir().join("conf.cfg")) {
             let reader = BufReader::new(file);
             for line in reader.lines() {
                 let line = line.unwrap();
@@ -203,7 +205,8 @@ impl Vars {
     }
 
     pub fn save_config(&self) {
-        let mut file = BufWriter::new(fs::File::create("conf.cfg").unwrap());
+        let mut file =
+            BufWriter::new(fs::File::create(paths::get_config_dir().join("conf.cfg")).unwrap());
         for (name, var) in &self.vars {
             if !var.can_serialize() {
                 continue;
@@ -250,7 +253,8 @@ impl Console {
         Console {
             history: vec![Component::Text(TextComponent::new("")); 200],
             dirty: false,
-            logfile: fs::File::create("client.log").expect("failed to open log file"),
+            logfile: fs::File::create(paths::get_cache_dir().join("client.log"))
+                .expect("failed to open log file"),
             log_level_term: log::Level::Info,
             log_level_file: log::Level::Trace,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ pub mod console;
 pub mod entity;
 mod inventory;
 pub mod model;
+pub mod paths;
 pub mod render;
 pub mod resources;
 pub mod screen;
@@ -195,20 +196,6 @@ struct Opt {
     default_protocol_version: Option<String>,
 }
 
-fn init_config_dir() {
-    if std::path::Path::new("conf.cfg").exists() {
-        return;
-    }
-
-    if let Some(mut path) = dirs::config_dir() {
-        path.push("leafish");
-        if !path.exists() {
-            std::fs::create_dir_all(path.clone()).unwrap();
-        }
-        std::env::set_current_dir(path).unwrap();
-    }
-}
-
 // TODO: Hide own character and show only the right hand. (with an item)
 // TODO: Simplify error messages in server list.
 // TODO: Render skin of players joining after one self.
@@ -218,7 +205,6 @@ fn init_config_dir() {
 // TODO: Improve clouds.
 // TODO: Fix pistons.
 fn main() {
-    init_config_dir();
     let opt = Opt::from_args();
     let con = Arc::new(Mutex::new(console::Console::new()));
     let proxy = console::ConsoleProxy::new(con.clone());

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn get_dir(dirtype: Option<PathBuf>) -> PathBuf {
+    match dirtype {
+        Some(path) => {
+            let mut path = path;
+            path.push("leafish");
+            if !path.exists() {
+                fs::create_dir_all(path.clone()).unwrap();
+            }
+            path
+        }
+        None => panic!("Unsupported platform"),
+    }
+}
+
+pub fn get_config_dir() -> PathBuf {
+    get_dir(dirs::config_dir())
+}
+
+pub fn get_cache_dir() -> PathBuf {
+    get_dir(dirs::cache_dir())
+}
+
+pub fn get_data_dir() -> PathBuf {
+    get_dir(dirs::data_dir())
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -23,6 +23,7 @@ pub mod model;
 pub mod ui;
 
 use crate::gl;
+use crate::paths;
 use crate::resources;
 use byteorder::{NativeEndian, WriteBytesExt};
 use cgmath::prelude::*;
@@ -1111,7 +1112,7 @@ impl TextureManager {
         use std::io::Read;
         use std::io::{Error, ErrorKind};
         use std::path::Path;
-        let path = format!("skin-cache/{}/{}.png", &hash[..2], hash);
+        let path = paths::get_cache_dir().join(format!("skin-cache/{}/{}.png", &hash[..2], hash));
         let cache_path = Path::new(&path);
         fs::create_dir_all(cache_path.parent().unwrap())?;
         let mut buf = vec![];

--- a/src/screen/delete_server.rs
+++ b/src/screen/delete_server.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 
+use crate::paths;
 use crate::render;
 use crate::settings;
 use crate::ui;
@@ -56,7 +57,7 @@ impl DeleteServerEntry {
     }
 
     fn delete_server(index: usize) {
-        let mut servers_info = match fs::File::open("servers.json") {
+        let mut servers_info = match fs::File::open(paths::get_data_dir().join("servers.json")) {
             Ok(val) => serde_json::from_reader(val).unwrap(),
             Err(_) => {
                 let mut info = BTreeMap::default();
@@ -76,7 +77,7 @@ impl DeleteServerEntry {
             servers.remove(index);
         }
 
-        let mut out = fs::File::create("servers.json").unwrap();
+        let mut out = fs::File::create(paths::get_data_dir().join("servers.json")).unwrap();
         serde_json::to_writer_pretty(&mut out, &servers_info).unwrap();
     }
 }

--- a/src/screen/edit_server.rs
+++ b/src/screen/edit_server.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 
+use crate::paths;
 use crate::ui;
 use crate::{render, settings};
 
@@ -43,7 +44,7 @@ impl EditServerEntry {
     }
 
     fn save_servers(index: Option<usize>, name: &str, address: &str) {
-        let mut servers_info = match fs::File::open("servers.json") {
+        let mut servers_info = match fs::File::open(paths::get_data_dir().join("servers.json")) {
             Ok(val) => serde_json::from_reader(val).unwrap(),
             Err(_) => {
                 let mut info = BTreeMap::default();

--- a/src/screen/server_list.rs
+++ b/src/screen/server_list.rs
@@ -20,6 +20,7 @@ use std::thread;
 
 use crate::format;
 use crate::format::{Component, TextComponent};
+use crate::paths;
 use crate::protocol;
 use crate::render;
 use crate::settings;
@@ -122,7 +123,7 @@ impl ServerList {
         }
         elements.servers.clear();
 
-        let file = match fs::File::open("servers.json") {
+        let file = match fs::File::open(paths::get_data_dir().join("servers.json")) {
             Ok(val) => val,
             Err(_) => return,
         };


### PR DESCRIPTION
This means:
- configs will be stored in $XDG_CONFIG_DIR/leafish with as fallback
  ~/.config/leafish
- data will be stored in $XDG_DATA_DIR/leafish with as fallback
  ~/.local/share/leafish
- cache and logs will be stored in $XDG_CACHE_DIR/leafish with as fallback
  ~/.cache/share/leafish

On Windows and macOS it uses their respective directories for this as
well.

Fixes #121.