### PR TITLE
Change to correct links

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -22,5 +22,5 @@ jobs:
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: leafish.flatpak
-        manifest-path: packaging/flatpak/com.github.terrarier2111.Leafish.yaml
+        manifest-path: packaging/flatpak/com.github.Lea-fish.Leafish.yaml
         cache-key: flatpak-builder-${{ github.sha }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -22,5 +22,5 @@ jobs:
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: leafish.flatpak
-        manifest-path: packaging/flatpak/com.github.Lea-fish.Leafish.yaml
+        manifest-path: packaging/flatpak/com.github.Lea_fish.Leafish.yaml
         cache-key: flatpak-builder-${{ github.sha }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ authors = [ "Thinkofdeath <thinkofdeath@spigotmc.org>", "iceiix <ice_ix@protonma
 edition = "2018"
 resolver = "2"
 description = "Multi-protocol multi-platform Minecraft-compatible client"
-repository = "https://github.com/terrarier2111/Leafish"
+repository = "https://github.com/Lea-fish/Leafish"
 license = "MIT/Apache-2.0"
 
 [package.metadata.bundle]
 name = "Leafish"
-identifier = "io.github.terrarier2111.leafish"
+identifier = "com.github.Lea-fish.Leafish"
 icon = ["resources/icon*.png"]
 category = "Game"
 osx_minimum_system_version = "10.14"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Being written in Rust with support for modern graphic API's like Vulkan means pe
 It's also completely community driven!
 
 Note that currently not everything from the original game is supported yet so Leafish can't currently be seen as a fully fledged alternative.
-A list of missing features is available on the [issues page](https://github.com/terrarier2111/Leafish/issues).
+A list of missing features is available on the [issues page](https://github.com/Lea-fish/Leafish/issues).
 
 ## Version support
 
@@ -97,7 +97,7 @@ Support for older protocols will _not_ be dropped as newer protocols are added.
 ### Downloading a pre-built version
 
 Since there currently is no release yet, pre-built binaries have to be downloaded from Github Actions.
-The latest actions can always be seen [here](https://github.com/terrarier2111/Leafish/actions).
+The latest actions can always be seen [here](https://github.com/Lea-fish/Leafish/actions).
 Click on a workflow run from the main branch and download the artifact for your platform.
 
 ### Building the game
@@ -141,7 +141,7 @@ If nothing happens consider running the executable from the command-line, `./lea
 
 ## Contributing
 
-A list of bugs and missing features can be found on the [issue tracker](https://github.com/terrarier2111/Leafish/issues/).
+A list of bugs and missing features can be found on the [issue tracker](https://github.com/Lea-fish/Leafish/issues/).
 Feel free to work on any bug and submit a pull request to the `main` branch with the fix.
 Mentioning that you intend to fix a bug on the issue will prevent other people from trying as well and makes sure no duplicated work is done.
 

--- a/packaging/flatpak/com.github.Lea-fish.Leafish.yaml
+++ b/packaging/flatpak/com.github.Lea-fish.Leafish.yaml
@@ -1,4 +1,4 @@
-app-id: com.github.terrarier2111.Leafish
+app-id: com.github.Lea-fish.Leafish
 runtime: org.freedesktop.Platform
 runtime-version: '20.08'
 sdk: org.freedesktop.Sdk

--- a/packaging/flatpak/com.github.Lea_fish.Leafish.yaml
+++ b/packaging/flatpak/com.github.Lea_fish.Leafish.yaml
@@ -1,4 +1,4 @@
-app-id: com.github.Lea-fish.Leafish
+app-id: com.github.Lea_fish.Leafish
 runtime: org.freedesktop.Platform
 runtime-version: '20.08'
 sdk: org.freedesktop.Sdk

--- a/packaging/leafish.metainfo.xml
+++ b/packaging/leafish.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>com.github.terrarier2111.Leafish</id>
-  <url type="homepage">https://github.com/terrarier2111/Leafish</url>
+  <id>com.github.Lea-fish.Leafish</id>
+  <url type="homepage">https://github.com/Lea-fish/Leafish</url>
 
   <name>Leafish</name>
   <summary>Multi-version Minecraft-compatible client written in Rust.</summary>
@@ -14,10 +14,10 @@
     <p>Minecraft is originally written by Mojang in Java for PC, but nowadays also has a so-called "Bedrock edition" which has ports to various alternative platforms. Leafish attempts to provide everything from the Java-edition and tries to be compatible with it so you can join regular servers and play alongside people using the official Java-based clients. Being written in Rust with support for modern graphic API's like Vulkan means performance improvements and enhancements that are not possible in the original game. It's also completely community driven!</p>
   </description>
 
-  <launchable type="desktop-id">com.github.terrarier2111.Leafish.desktop</launchable>
+  <launchable type="desktop-id">com.github.Lea-fish.Leafish.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/terrarier2111/Leafish/main/.github/readme-resources/screenshot-mainmenu.jpg</image>
+      <image>https://raw.githubusercontent.com/Lea-fish/Leafish/main/.github/readme-resources/screenshot-mainmenu.jpg</image>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1" />


### PR DESCRIPTION
- Switch repo links to https://github.com/Lea-fish/Leafish
- Change reverse DNS schema to `com.github.Lea-fish.Leafish`

Closes https://github.com/Lea-fish/Leafish/issues/124.