### PR TITLE
Store authentication settings in data dir rather than config dir

### DIFF
--- a/src/screen/login.rs
+++ b/src/screen/login.rs
@@ -30,6 +30,7 @@ use crate::ui;
 pub struct Login {
     elements: Option<UIElements>,
     vars: Rc<console::Vars>,
+    auth_vars: Rc<console::Vars>,
 }
 
 struct UIElements {
@@ -49,10 +50,11 @@ struct UIElements {
 }
 
 impl Login {
-    pub fn new(vars: Rc<console::Vars>) -> Login {
+    pub fn new(vars: Rc<console::Vars>, auth_vars: Rc<console::Vars>) -> Login {
         Login {
             elements: None,
             vars,
+            auth_vars,
         }
     }
 }
@@ -130,9 +132,9 @@ impl super::Screen for Login {
             .create(ui_container);
 
         let profile = mojang::Profile {
-            username: self.vars.get(auth::CL_USERNAME).clone(),
-            id: self.vars.get(auth::CL_UUID).clone(),
-            access_token: self.vars.get(auth::AUTH_TOKEN).clone(),
+            username: self.auth_vars.get(auth::CL_USERNAME).clone(),
+            id: self.auth_vars.get(auth::CL_UUID).clone(),
+            access_token: self.auth_vars.get(auth::AUTH_TOKEN).clone(),
         };
         let refresh = profile.is_complete();
         try_login.set(refresh);
@@ -172,15 +174,15 @@ impl super::Screen for Login {
             elements.login_res = Some(rx);
             elements.login_btn.borrow_mut().disabled = true;
             elements.login_btn_text.borrow_mut().text = "Logging in...".into();
-            let mut client_token = self.vars.get(auth::AUTH_CLIENT_TOKEN).clone();
+            let mut client_token = self.auth_vars.get(auth::AUTH_CLIENT_TOKEN).clone();
             if client_token.is_empty() {
                 client_token = std::iter::repeat(())
                     .map(|()| rand::thread_rng().sample(&rand::distributions::Alphanumeric) as char)
                     .take(20)
                     .collect();
-                self.vars.set(auth::AUTH_CLIENT_TOKEN, client_token);
+                self.auth_vars.set(auth::AUTH_CLIENT_TOKEN, client_token);
             }
-            let client_token = self.vars.get(auth::AUTH_CLIENT_TOKEN).clone();
+            let client_token = self.auth_vars.get(auth::AUTH_CLIENT_TOKEN).clone();
             let username = elements.username_txt.borrow().input.clone();
             let password = elements.password_txt.borrow().input.clone();
             let refresh = elements.refresh;
@@ -202,9 +204,10 @@ impl super::Screen for Login {
                 elements.login_btn_text.borrow_mut().text = "Login".into();
                 match res {
                     Ok(val) => {
-                        self.vars.set(auth::CL_USERNAME, val.username.clone());
-                        self.vars.set(auth::CL_UUID, val.id.clone());
-                        self.vars.set(auth::AUTH_TOKEN, val.access_token.clone());
+                        self.auth_vars.set(auth::CL_USERNAME, val.username.clone());
+                        self.auth_vars.set(auth::CL_UUID, val.id.clone());
+                        self.auth_vars
+                            .set(auth::AUTH_TOKEN, val.access_token.clone());
                         elements.profile = val;
                         return Some(Box::new(super::ServerList::new(
                             None,


### PR DESCRIPTION
This allows people to share their config file with others (who knows why people might do that, but I know it happens for other types of programs) without accidentally sharing their authentication token.

Eventually these should be stored in a secure place like GNOME and KDE Plasma provide, token wallets (or whatever they are called), using libsecret.

Depends on #128 and this shouldn't be merged first.