### PR TITLE
Add support for displaying chat messages in game.

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2511,6 +2511,10 @@ impl Server {
         _sender: Option<protocol::UUID>,
     ) {
         info!("Received chat message: {}", message);
+        self.hud_context
+            .clone()
+            .write()
+            .display_message_in_chat(message.clone());
         self.received_chat_at
             .clone()
             .write()


### PR DESCRIPTION
Add support for displaying chat messages. This PR does not add support for sending chat. Currently, there is a bug where messages that are too long overlap each other, but I don't have the time to fix this because of uni starting again.

Related to #41 

![](https://user-images.githubusercontent.com/9784257/132852192-562578db-0c98-498d-81d9-a851dd28566f.png)
