### PR TITLE
Only write received messages to console when debugging

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2672,7 +2672,7 @@ impl Server {
         _position: Option<u8>,
         _sender: Option<protocol::UUID>,
     ) {
-        info!("Received chat message: {}", message);
+        debug!("Received chat message: {}", message);
         self.hud_context
             .clone()
             .write()


### PR DESCRIPTION
Now we have visual chat on the screen, we really don't need our terminal spammed with messages from the server