### PR TITLE
remove render debug msg

### DIFF
--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -378,41 +378,41 @@ impl Console {
 
         if record.level() <= self.log_level_term {
             println!("{}", line);
-        }
 
-        self.history.remove(0);
-        let mut msg = TextComponent::new("");
-        msg.modifier.extra = Some(vec![
-            Component::Text(TextComponent::new("[")),
-            {
-                let mut msg = TextComponent::new(file);
-                msg.modifier.color = Some(Color::Green);
-                Component::Text(msg)
-            },
-            Component::Text(TextComponent::new(":")),
-            {
-                let mut msg = TextComponent::new(&format!("{}", record.line().unwrap_or(0)));
-                msg.modifier.color = Some(Color::Aqua);
-                Component::Text(msg)
-            },
-            Component::Text(TextComponent::new("]")),
-            Component::Text(TextComponent::new("[")),
-            {
-                let mut msg = TextComponent::new(&format!("{}", record.level()));
-                msg.modifier.color = Some(match record.level() {
-                    log::Level::Debug => Color::Green,
-                    log::Level::Error => Color::Red,
-                    log::Level::Warn => Color::Yellow,
-                    log::Level::Info => Color::Aqua,
-                    log::Level::Trace => Color::Blue,
-                });
-                Component::Text(msg)
-            },
-            Component::Text(TextComponent::new("] ")),
-            Component::Text(TextComponent::new(&format!("{}", record.args()))),
-        ]);
-        self.history.push(Component::Text(msg));
-        self.dirty = true;
+            self.history.remove(0);
+            let mut msg = TextComponent::new("");
+            msg.modifier.extra = Some(vec![
+                Component::Text(TextComponent::new("[")),
+                {
+                    let mut msg = TextComponent::new(file);
+                    msg.modifier.color = Some(Color::Green);
+                    Component::Text(msg)
+                },
+                Component::Text(TextComponent::new(":")),
+                {
+                    let mut msg = TextComponent::new(&format!("{}", record.line().unwrap_or(0)));
+                    msg.modifier.color = Some(Color::Aqua);
+                    Component::Text(msg)
+                },
+                Component::Text(TextComponent::new("]")),
+                Component::Text(TextComponent::new("[")),
+                {
+                    let mut msg = TextComponent::new(&format!("{}", record.level()));
+                    msg.modifier.color = Some(match record.level() {
+                        log::Level::Debug => Color::Green,
+                        log::Level::Error => Color::Red,
+                        log::Level::Warn => Color::Yellow,
+                        log::Level::Info => Color::Aqua,
+                        log::Level::Trace => Color::Blue,
+                    });
+                    Component::Text(msg)
+                },
+                Component::Text(TextComponent::new("] ")),
+                Component::Text(TextComponent::new(&format!("{}", record.args()))),
+            ]);
+            self.history.push(Component::Text(msg));
+            self.dirty = true;
+        }
     }
 }
 

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -264,9 +264,36 @@ impl Console {
         }
     }
 
+    fn set_log_level_from_enviroment_variable(
+        level: &mut log::Level,
+        iter: std::slice::Iter<&str>,
+        default: log::Level,
+    ) {
+        for name in iter {
+            match std::env::var(name) {
+                Ok(var) => {
+                    *level = log_level_from_str(&var, default);
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
     pub fn configure(&mut self, vars: &Vars) {
         self.log_level_term = log_level_from_str(&vars.get(LOG_LEVEL_TERM), log::Level::Info);
-        self.log_level_file = log_level_from_str(&vars.get(LOG_LEVEL_FILE), log::Level::Trace);
+        self.log_level_file = log_level_from_str(&vars.get(LOG_LEVEL_FILE), log::Level::Debug);
+
+        Console::set_log_level_from_enviroment_variable(
+            &mut self.log_level_term,
+            ["RUST_LOG", "LOG_LEVEL", "LOG_LEVEL_TERM"].iter(),
+            log::Level::Info,
+        );
+
+        Console::set_log_level_from_enviroment_variable(
+            &mut self.log_level_file,
+            ["RUST_LOG", "LOG_LEVEL", "LOG_LEVEL_FILE"].iter(),
+            log::Level::Debug,
+        );
     }
 
     pub fn is_active(&self) -> bool {

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -270,11 +270,8 @@ impl Console {
         default: log::Level,
     ) {
         for name in iter {
-            match std::env::var(name) {
-                Ok(var) => {
-                    *level = log_level_from_str(&var, default);
-                }
-                Err(_) => {}
+            if let Ok(var) = std::env::var(name) {
+                *level = log_level_from_str(&var, default);
             }
         }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -28,7 +28,7 @@ use crate::resources;
 use byteorder::{NativeEndian, WriteBytesExt};
 use cgmath::prelude::*;
 use image::{GenericImage, GenericImageView, RgbaImage};
-use log::{debug, error, trace};
+use log::{error, trace};
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
@@ -369,11 +369,7 @@ impl Renderer {
                             self.element_buffer_type,
                             0,
                         );
-                    } else {
-                        debug!("1: not rendering solid {:?}", pos);
                     }
-                } else {
-                    debug!("2: not rendering solid {:?}", pos);
                 }
             }
 
@@ -470,11 +466,7 @@ impl Renderer {
                             self.element_buffer_type,
                             0,
                         );
-                    } else {
-                        debug!("1: not rendering trans {:?}", pos);
                     }
-                } else {
-                    debug!("2: not rendering trans {:?}", pos);
                 }
             }
         }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use log::{debug, warn};
+use log::warn;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -585,8 +585,6 @@ impl World {
         });
         if !out.read().is_empty() {
             self.do_render_queue(out, frustum, frame_id, valid_dirs, render_queue);
-        } else {
-            debug!("finished!");
         }
     }
 


### PR DESCRIPTION
now you can override log level with enviroment variabels example of what to do. 

higherkey 
Default > Config file > environment variables. 

- `cargo run` -> reads from config file and sets level
- `RUST_LOG=trace cargo run` -> overrides values from config file and sets both logs to trace.
- `LOG_LEVEL=trace cargo run` -> same as above 
- `RUST_LOG=trace LOG_LEVEL_TERM=debug cargo run` -> still overrides default values but this time, file_log is set to trace and console_log is set to debug.
- `RUST_LOG=trace LOG_LEVEL_FILE=debug cargo run` -> still override defaults values but this time, console_log is set to debug and file_log is set to trace.
- `LOG_LEVEL_FILE=trace cargo run` -> override only file_log to trace.
- `LOG_LEVEL_TERM=trace cargo run` -> override only console_log to trace.