### PR TITLE
fix #97 cursor visibility/cursor-grab when in under menu

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -737,7 +737,9 @@ fn handle_window_event<T>(
                                     window.set_cursor_grab(true).unwrap();
                                     window.set_cursor_visible(false);
                                     game.focused = true;
-                                    game.screen_sys.pop_screen();
+                                    while game.screen_sys.is_current_closable() {
+                                        game.screen_sys.pop_screen();
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
closes #97 
Every time we open's a under menu, we add that screen to the stack. 
If we then are in 'Video Settings menu' when we are 2 stacks down and it is not possible to go down further with the code before.
Now it clears all the screen when you press escape, because it keeps checking if it can close the window's
if it can it pops it from the stack.