### PR TITLE
Fix pure ipaddreses (ip's without a port) could not resolve.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Package binary
         run: |
-          cargo install --force cargo-bundle
+          cargo install cargo-bundle || echo "cargo-bundle already installed"
           cargo bundle --release
           chmod a+x target/release/bundle/osx/Leafish.app/Contents/MacOS/leafish
           cd target/release/bundle/osx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "andrew"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,7 +1212,6 @@ dependencies = [
  "leafish_shared",
  "log",
  "num-traits",
- "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -2139,23 +2129,6 @@ dependencies = [
  "getrandom",
  "redox_syscall",
 ]
-
-[[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -21,7 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,8 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> b7aae0f (Remove regex for parsing ip's using rust default lib)
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +40,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> b7aae0f (Remove regex for parsing ip's using rust default lib)
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,7 +555,6 @@ dependencies = [
  "leafish_shared",
  "log",
  "num-traits",
- "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -1007,23 +1009,6 @@ checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -18,7 +18,6 @@ num-traits = "0.2.14"
 instant = "0.1.9"
 cgmath = "0.17.0"
 
-regex = "1.5.4"
 lazy_static = "1.4.0"
 trust-dns-resolver = "0.20.3"
 # srv-rs = { version = "0.2.0", features = ["libresolv"] }

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -16,7 +16,6 @@
 #![allow(non_camel_case_types)]
 
 extern crate lazy_static;
-extern crate regex;
 
 use std::convert;
 use std::default;
@@ -38,7 +37,6 @@ use instant::{Duration, Instant};
 use lazy_static::lazy_static;
 use log::{debug, warn};
 use num_traits::cast::{cast, NumCast};
-use regex::Regex;
 use trust_dns_resolver::config::ResolverConfig;
 use trust_dns_resolver::config::ResolverOpts;
 use trust_dns_resolver::Resolver;
@@ -1116,17 +1114,6 @@ pub struct Conn {
 }
 
 lazy_static! {
-    static ref IPADDRESS_PATTERN: Regex = Regex::new(
-        format!(
-            "{}{}{}{}",
-            "^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.",
-            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.",
-            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.",
-            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])$"
-        )
-        .as_str()
-    )
-    .unwrap();
     static ref RESOLVER: Resolver =
         Resolver::new(ResolverConfig::default(), ResolverOpts::default()).unwrap();
 }
@@ -1163,7 +1150,8 @@ impl Conn {
             }
         }
 
-        if !IPADDRESS_PATTERN.is_match(&address) {
+        use std::str::FromStr;
+        if let Err(_) = std::net::IpAddr::from_str(&address) {
             debug!("address: {} is not an IP", address);
             for (adresse, port) in Conn::get_server_addresses(&address) {
                 debug!("{}'s ip may be {}:{}.", target, adresse, port);

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1132,43 +1132,57 @@ lazy_static! {
 }
 
 impl Conn {
-    fn get_server_addresses(mut hostname: &str) -> Vec<String> {
+    fn get_server_addresses(hostname: &str) -> Vec<(String, u16)> {
         let mut addresses = vec![];
-        let parts = hostname.split(':').collect::<Vec<&str>>();
-        if parts.len() > 1 {
-            addresses.push(hostname.to_string());
-            hostname = parts[0];
-        }
+
         let records = RESOLVER.srv_lookup(format!("_minecraft._tcp.{}", hostname));
         if records.is_ok() {
             for record in records.unwrap() {
                 debug!("{}:{}", record.target(), record.port());
-                addresses.push(format!("{}:{}", record.target(), record.port()));
+                addresses.push((record.target().to_string(), record.port()));
             }
         }
-        addresses.push(format!("{}:25565", hostname));
+        addresses.push((hostname.to_string(), 25565));
         addresses
     }
 
     pub fn new(target: &str, protocol_version: i32) -> Result<Conn, Error> {
         CURRENT_PROTOCOL_VERSION.store(protocol_version, Ordering::Relaxed);
-
         let mut address = target.to_string();
-        if !IPADDRESS_PATTERN.is_match(target) {
-            debug!("{} has an no address! :(", address);
-            let result = Conn::get_server_addresses(target);
-            // TODO: Try all possible ips not just the first!
-            let next = result.iter().next().unwrap();
-            debug!("{}'s ip may be {}.", address, next);
-            address = next.to_string();
+        let mut port = 25565;
+
+        if target.contains(':') {
+            let (l_address, l_port) = target
+                .split_once(':')
+                .expect("already checked for ':' so this would never crash");
+            address = l_address.to_string();
+            if let Ok(l_port) = l_port.parse() {
+                port = l_port;
+            } else {
+                return Err(Error::Err("Bad port".to_string()));
+            }
         }
 
-        let stream = TcpStream::connect(&*address)?;
-        let parts = address.split(':').collect::<Vec<&str>>();
+        if !IPADDRESS_PATTERN.is_match(&address) {
+            debug!("address: {} is not an IP", address);
+            for (adresse, port) in Conn::get_server_addresses(&address) {
+                debug!("{}'s ip may be {}:{}.", target, adresse, port);
+                if let Ok(conn) = Conn::try_stream(&adresse, port, protocol_version) {
+                    return Ok(conn);
+                }
+            }
+        }
+
+        debug!("{}'s ip may be {}:{}.", target, address, port);
+        Conn::try_stream(&address, port, protocol_version)
+    }
+
+    fn try_stream(addres: &str, port: u16, protocol_version: i32) -> Result<Conn, Error> {
+        let stream = TcpStream::connect(format!("{}:{}", addres, port))?;
         Ok(Conn {
-            stream: stream,
-            host: parts[0].to_owned(),
-            port: parts[1].parse().unwrap(),
+            stream,
+            host: addres.to_string(),
+            port,
             direction: Direction::Serverbound,
             state: State::Handshaking,
             protocol_version,

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1138,12 +1138,9 @@ impl Conn {
         let mut address = target.to_string();
         let mut port = 25565;
 
-        if target.contains(':') {
-            let (l_address, l_port) = target
-                .split_once(':')
-                .expect("already checked for ':' so this would never crash");
-            address = l_address.to_string();
-            if let Ok(l_port) = l_port.parse() {
+        if let Some(fields) = target.split_once(':') {
+            address = fields.0.to_string();
+            if let Ok(l_port) = fields.1.parse() {
                 port = l_port;
             } else {
                 return Err(Error::Err("Bad port".to_string()));
@@ -1165,11 +1162,11 @@ impl Conn {
         Conn::try_stream(&address, port, protocol_version)
     }
 
-    fn try_stream(addres: &str, port: u16, protocol_version: i32) -> Result<Conn, Error> {
-        let stream = TcpStream::connect(format!("{}:{}", addres, port))?;
+    fn try_stream(address: &str, port: u16, protocol_version: i32) -> Result<Conn, Error> {
+        let stream = TcpStream::connect(format!("{}:{}", address, port))?;
         Ok(Conn {
             stream,
-            host: addres.to_string(),
+            host: address.to_string(),
             port,
             direction: Direction::Serverbound,
             state: State::Handshaking,


### PR DESCRIPTION
Fixes  #134
normal hostnames could be resolve without a port. it was only Ip adresses that could not. 

The name you can see in the server list is the same as the adress.
### Before
![210912-2038-55](https://user-images.githubusercontent.com/55736468/133000236-7fd1c3f4-ebd5-45a7-b19f-de787d1e53fc.png)


### Now
![image](https://user-images.githubusercontent.com/55736468/133000264-ac67f1ed-55f7-4e51-ba46-02ee079938b6.png)

I have simplified the code and it can still connect to server where it is protected by [TCPShield](https://tcpshield.com/).
I did throw in a empty server where the field is empty. 
also kkmp.dk does not exits. 

FIY this pr also removes  regex
