### PR TITLE
Fix loading of skin after downloading it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Package binary
         run: |
-          cargo install cargo-bundle
+          cargo install --force cargo-bundle
           cargo bundle --release
           chmod a+x target/release/bundle/osx/Leafish.app/Contents/MacOS/leafish
           cd target/release/bundle/osx

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1121,7 +1121,7 @@ impl TextureManager {
                     return Err(Error::new(ErrorKind::ConnectionAborted, err));
                 }
             };
-            let mut buf = vec![];
+
             match res.read_to_end(&mut buf) {
                 Ok(_) => {}
                 Err(err) => {


### PR DESCRIPTION
A new buffer was created in a limited scope rather than using the existing
buffer from the outer scope. Since the actual loading of the image was
in the outer scope, it was just reading an empty buffer and failed.