### PR TITLE
Fix panic where where subtract's overflows

### DIFF
--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -274,7 +274,7 @@ impl ScreenSystem {
                 .iter()
                 .skip(lowest as usize)
             {
-                let idx = self.screens.read().len() - 1;
+                let idx = (self.screens.read().len() as isize - 1).max(0) as usize;
                 self.screens.write().push(ScreenInfo {
                     screen: Arc::new(Mutex::new(screen.clone())),
                     active: false,


### PR DESCRIPTION
Fix a panic where screen tries to subtract 1 from 0 
0 - 1 = -1 
this panic only happens in debug builds, I think it is because rust builds it with checking for overflow there. 
Not sure why it don't do it in a release build

Not sure if it should be fixed like this or there i a logic error some place? 
I have not looked into it
```sh
    Finished dev [optimized + debuginfo] target(s) in 0.12s
     Running `target/debug/leafish`
[main.rs:220][INFO] Starting Leafish...
[main.rs:284][INFO] Shader version: #version 150
thread 'main' panicked at 'attempt to subtract with overflow', src/screen/mod.rs:269:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
zsh: segmentation fault (core dumped)  cargo run

```