### PR TITLE
README: add arch packages required for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,23 @@ Rust stable version 1.53.0 or newer is required.
 
 **Debian/Ubuntu**
 
+As current Debian stable (Bullseye) has a rust version below the required one, you need to either update from an external source, or consider using Debian Testing (Bookworm) for example.  
+For Ubuntu you might want to use the -updates repository for your version.
 ```sh
 sudo apt-get install cargo libssl-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libgtk-3-dev
 ```
 
 **Alpine Linux**
 
+You have to enable the community repository for `cargo`.
 ```sh
 sudo apk add cargo openssl-dev xcb-util-dev gtk+3.0-dev
+```
+
+**Arch Linux and derivates**
+
+```sh
+sudo pacman -S rust python3 pkgconf openssl xcb-util gtk3
 ```
 
 #### Building

--- a/README.md
+++ b/README.md
@@ -107,21 +107,21 @@ Rust stable version 1.53.0 or newer is required.
 
 As current Debian stable (Bullseye) has a rust version below the required one, you need to either update from an external source, or consider using Debian Testing (Bookworm) for example.  
 For Ubuntu you might want to use the -updates repository for your version.
-```sh
-sudo apt-get install cargo libssl-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libgtk-3-dev
+```
+# apt install cargo libssl-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libgtk-3-dev
 ```
 
 **Alpine Linux**
 
 You have to enable the community repository for `cargo`.
-```sh
-sudo apk add cargo openssl-dev xcb-util-dev gtk+3.0-dev
+```
+# apk add cargo openssl-dev xcb-util-dev gtk+3.0-dev
 ```
 
 **Arch Linux and derivates**
 
-```sh
-sudo pacman -S rust python3 pkgconf openssl xcb-util gtk3
+```
+# pacman -S rust python3 pkgconf openssl xcb-util gtk3
 ```
 
 #### Building
@@ -131,13 +131,13 @@ Make sure you're in the root of the Git repository before running the following 
 Compile and run:
 
 ```sh
-cargo run --release
+$ cargo run --release
 ```
 
 Just compile:
 
 ```sh
-cargo build --release
+$ cargo build --release
 ```
 
 #### Running


### PR DESCRIPTION
Arch Linux is one of the major GNU distributions, whose derivates (Parabola, Manjaro, soon SteamOS) are also widely used. Its packages are not split into binary and development files, this PR lists those required to build Leafish.

Since I was testing in a clean env, python3 and pkg-config were not installed, so I've added those to the others as well. Didn't test Debian or Alpine though, but they should be the correct packages.