### PR TITLE
Fix varint and varlong decoding

### DIFF
--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -900,10 +900,10 @@ impl Serializable for VarInt {
         loop {
             let b = buf.read_u8()? as u32;
             val |= (b & PART) << (size * 7);
-            size += 1;
             if size > 5 {
                 return Err(Error::Err("VarInt too big".to_owned()));
             }
+            size += 1;
             if (b & 0x80) == 0 {
                 break;
             }


### PR DESCRIPTION
This aims to fix varint/varlong decoding, based on the example implementations from [wiki.vg](https://wiki.vg/Protocol#VarInt_and_VarLong). Is yet to be tested. When this gets merged, please don't forget to delete the fix-varint-decoding branch, as it's not needed anymore.