### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -813,8 +813,8 @@ pub const DEPTH_ATTACHMENT: Attachment = gl::DEPTH_ATTACHMENT;
 pub struct Framebuffer(glow::Framebuffer);
 
 pub fn check_framebuffer_status() {
-    unsafe {
-        let status = glow_context().check_framebuffer_status(gl::FRAMEBUFFER);
+    
+        let status = unsafe { glow_context().check_framebuffer_status(gl::FRAMEBUFFER) }; 
         let s = match status {
             gl::FRAMEBUFFER_UNDEFINED => "GL_FRAMEBUFFER_UNDEFINED",
             gl::FRAMEBUFFER_INCOMPLETE_ATTACHMENT => "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT",
@@ -838,7 +838,7 @@ pub fn check_framebuffer_status() {
                 status, s
             );
         }
-    }
+    
 }
 
 pub fn check_gl_error() {


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html