### PR TITLE
Fix buffer overrun in light data

### DIFF
--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -120,7 +120,7 @@ impl Var for CVar<String> {
     }
 
     fn deserialize(&self, input: &str) -> Box<dyn Any> {
-        Box::new((&input[1..input.len() - 1]).to_owned())
+        Box::new(input[1..input.len() - 1].to_owned())
     }
 
     fn description(&self) -> &'static str {

--- a/src/render/hud.rs
+++ b/src/render/hud.rs
@@ -1166,15 +1166,14 @@ impl Hud {
             } else {
                 textures.1
             };
-        let image = ui::ImageBuilder::new()
+        ui::ImageBuilder::new()
             .draw_index(HUD_PRIORITY)
             .texture_coords((0.0, 0.0, 1.0, 1.0))
             .position(x, y)
             .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
             .size(icon_scale * 16.0, icon_scale * 16.0)
             .texture(format!("minecraft:{}", texture))
-            .create(ui_container);
-        image
+            .create(ui_container)
     }
 }
 

--- a/src/screen/edit_account.rs
+++ b/src/screen/edit_account.rs
@@ -19,10 +19,12 @@ use crate::screen::{Screen, ScreenSystem};
 use std::rc::Rc;
 use std::sync::Arc;
 
+type EditAccountEntryCallback = dyn Fn(&mut Game, String, String);
+
 pub struct EditAccountEntry {
     elements: Option<UIElements>,
     entry_info: Option<(String, String)>,
-    done_callback: Rc<dyn Fn(&mut Game, String, String)>, // game, name, password
+    done_callback: Rc<EditAccountEntryCallback>, // game, name, password
 }
 
 impl Clone for EditAccountEntry {
@@ -47,7 +49,7 @@ struct UIElements {
 impl EditAccountEntry {
     pub fn new(
         entry_info: Option<(String, String)>,
-        done_callback: Rc<dyn Fn(&mut Game, String, String)>,
+        done_callback: Rc<EditAccountEntryCallback>,
     ) -> Self {
         Self {
             elements: None,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1518,6 +1518,8 @@ impl Button {
     }
 }
 
+type TextBoxSubmitCallback = dyn Fn(&mut TextBox, &mut crate::Game);
+
 element! {
     ref TextBoxRef
     pub struct TextBox {
@@ -1529,7 +1531,7 @@ element! {
         priv text: Option<TextRef>,
         priv was_focused: bool,
         priv cursor_tick: f64,
-        priv submit_funcs: Vec<Box<dyn Fn(&mut TextBox, &mut crate::Game)>>,
+        priv submit_funcs: Vec<Box<TextBoxSubmitCallback>>,
     }
     builder TextBoxBuilder {
         hardcode button = None,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1285,7 +1285,7 @@ impl World {
                 if i == 0 {
                     let _size = VarInt::read_from(data);
 
-                    data.consume(16 * 16 * 16);
+                    data.consume(2048);
                     continue;
                 }
                 let i = i - 1;
@@ -1301,7 +1301,7 @@ impl World {
         if sky_light_mask & (1 << 63) != 0 {
             let _size = VarInt::read_from(data);
 
-            data.consume(16 * 16 * 16);
+            data.consume(2048);
         }
         for i in 0..17 {
             if block_light_mask & (1 << i) == 0 {
@@ -1310,7 +1310,7 @@ impl World {
             if i == 0 {
                 let _size = VarInt::read_from(data);
 
-                data.consume(16 * 16 * 16);
+                data.consume(2048);
                 continue;
             }
             let i = i - 1;


### PR DESCRIPTION
We seem to be reading 4096 bytes rather than 2048 bytes per section in some cases. The array should always be 2048, 4 bits for each block in the chunk section (https://wiki.vg/index.php?title=Protocol&oldid=16317#Update_Light).