### PR TITLE
Refactor break blocks to use calculated mining time

### DIFF
--- a/blocks/src/bin/dump_block.rs
+++ b/blocks/src/bin/dump_block.rs
@@ -1,7 +1,7 @@
 use leafish_blocks::VanillaIDMap;
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::env;
-use parking_lot::RwLock;
 use std::sync::Arc;
 
 fn main() {

--- a/blocks/src/bin/dump_block.rs
+++ b/blocks/src/bin/dump_block.rs
@@ -1,6 +1,8 @@
 use leafish_blocks::VanillaIDMap;
 use std::collections::HashMap;
 use std::env;
+use parking_lot::RwLock;
+use std::sync::Arc;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -15,7 +17,7 @@ fn main() {
     let id = str::parse::<usize>(&args[2]).unwrap();
 
     let id_map = VanillaIDMap::new(protocol_version);
-    let block = id_map.by_vanilla_id(id, &HashMap::new());
+    let block = id_map.by_vanilla_id(id, Arc::new(RwLock::new(HashMap::new())));
 
     println!("{:?}", block);
 }

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -6597,97 +6597,199 @@ mod tests {
 
     #[test]
     fn verify_blocks() {
-        let dirt = Block::Dirt { snowy: true, variant: DirtVariant::Normal };
-        let stone = Block::Stone { variant: StoneVariant::Normal };
-        let vine = Block::Vine { up: false, south: false, west: false, north: true, east: false };
-        let pumpkin_lit = Block::PumpkinLit { facing: Direction::North, without_face: true };
-        let cocoa = Block::Cocoa { age: 1, facing: Direction::North };
-        let leaves = Block::Leaves { variant: TreeVariant::Oak, decayable: false, check_decay: false, distance: 1 };
-        let leaves2 = Block::Leaves2 { variant: TreeVariant::Oak, decayable: false, check_decay: false };
-        let wool = Block::Wool { color: ColoredVariant::White };
-        let tall_seagrass = Block::TallSeagrass { half: TallSeagrassHalf::Upper };
+        let dirt = Block::Dirt {
+            snowy: true,
+            variant: DirtVariant::Normal,
+        };
+        let stone = Block::Stone {
+            variant: StoneVariant::Normal,
+        };
+        let vine = Block::Vine {
+            up: false,
+            south: false,
+            west: false,
+            north: true,
+            east: false,
+        };
+        let pumpkin_lit = Block::PumpkinLit {
+            facing: Direction::North,
+            without_face: true,
+        };
+        let cocoa = Block::Cocoa {
+            age: 1,
+            facing: Direction::North,
+        };
+        let leaves = Block::Leaves {
+            variant: TreeVariant::Oak,
+            decayable: false,
+            check_decay: false,
+            distance: 1,
+        };
+        let leaves2 = Block::Leaves2 {
+            variant: TreeVariant::Oak,
+            decayable: false,
+            check_decay: false,
+        };
+        let wool = Block::Wool {
+            color: ColoredVariant::White,
+        };
+        let tall_seagrass = Block::TallSeagrass {
+            half: TallSeagrassHalf::Upper,
+        };
         let data = [
             (dirt, None, Some(0.75)),
             (dirt, Some(Tool::Shovel(ToolMaterial::Wood)), Some(0.4)),
             (dirt, Some(Tool::Pickaxe(ToolMaterial::Wood)), Some(0.75)),
-
             (stone, None, Some(7.5)),
             (stone, Some(Tool::Shovel(ToolMaterial::Wood)), Some(7.5)),
             (stone, Some(Tool::Pickaxe(ToolMaterial::Wood)), Some(1.15)),
-
             (Block::Obsidian {}, None, Some(250.0)),
-            (Block::Obsidian {}, Some(Tool::Pickaxe(ToolMaterial::Wood)), Some(125.0)),
-            (Block::Obsidian {}, Some(Tool::Pickaxe(ToolMaterial::Stone)), Some(62.5)),
-            (Block::Obsidian {}, Some(Tool::Pickaxe(ToolMaterial::Iron)), Some(41.7)),
-            (Block::Obsidian {}, Some(Tool::Pickaxe(ToolMaterial::Diamond)), Some(9.4)),
-            (Block::Obsidian {}, Some(Tool::Pickaxe(ToolMaterial::Netherite)), Some(8.35)),
-            (Block::Obsidian {}, Some(Tool::Pickaxe(ToolMaterial::Gold)), Some(20.85)),
-
+            (
+                Block::Obsidian {},
+                Some(Tool::Pickaxe(ToolMaterial::Wood)),
+                Some(125.0),
+            ),
+            (
+                Block::Obsidian {},
+                Some(Tool::Pickaxe(ToolMaterial::Stone)),
+                Some(62.5),
+            ),
+            (
+                Block::Obsidian {},
+                Some(Tool::Pickaxe(ToolMaterial::Iron)),
+                Some(41.7),
+            ),
+            (
+                Block::Obsidian {},
+                Some(Tool::Pickaxe(ToolMaterial::Diamond)),
+                Some(9.4),
+            ),
+            (
+                Block::Obsidian {},
+                Some(Tool::Pickaxe(ToolMaterial::Netherite)),
+                Some(8.35),
+            ),
+            (
+                Block::Obsidian {},
+                Some(Tool::Pickaxe(ToolMaterial::Gold)),
+                Some(20.85),
+            ),
             (Block::Bedrock {}, None, None),
-            (Block::Bedrock {}, Some(Tool::Pickaxe(ToolMaterial::Wood)), None),
-            (Block::Bedrock {}, Some(Tool::Pickaxe(ToolMaterial::Stone)), None),
-            (Block::Bedrock {}, Some(Tool::Pickaxe(ToolMaterial::Iron)), None),
-            (Block::Bedrock {}, Some(Tool::Pickaxe(ToolMaterial::Diamond)), None),
-            (Block::Bedrock {}, Some(Tool::Pickaxe(ToolMaterial::Netherite)), None),
-            (Block::Bedrock {}, Some(Tool::Pickaxe(ToolMaterial::Gold)), None),
-
+            (
+                Block::Bedrock {},
+                Some(Tool::Pickaxe(ToolMaterial::Wood)),
+                None,
+            ),
+            (
+                Block::Bedrock {},
+                Some(Tool::Pickaxe(ToolMaterial::Stone)),
+                None,
+            ),
+            (
+                Block::Bedrock {},
+                Some(Tool::Pickaxe(ToolMaterial::Iron)),
+                None,
+            ),
+            (
+                Block::Bedrock {},
+                Some(Tool::Pickaxe(ToolMaterial::Diamond)),
+                None,
+            ),
+            (
+                Block::Bedrock {},
+                Some(Tool::Pickaxe(ToolMaterial::Netherite)),
+                None,
+            ),
+            (
+                Block::Bedrock {},
+                Some(Tool::Pickaxe(ToolMaterial::Gold)),
+                None,
+            ),
             (Block::Web {}, None, Some(20.0)),
-            (Block::Web {}, Some(Tool::Pickaxe(ToolMaterial::Wood)), Some(20.0)),
-
+            (
+                Block::Web {},
+                Some(Tool::Pickaxe(ToolMaterial::Wood)),
+                Some(20.0),
+            ),
             (vine, None, Some(0.3)),
             (vine, Some(Tool::Pickaxe(ToolMaterial::Wood)), Some(0.3)),
             (vine, Some(Tool::Axe(ToolMaterial::Wood)), Some(0.15)),
             (vine, Some(Tool::Axe(ToolMaterial::Stone)), Some(0.1)),
             (vine, Some(Tool::Axe(ToolMaterial::Iron)), Some(0.05)),
             (vine, Some(Tool::Axe(ToolMaterial::Diamond)), Some(0.05)),
-
             (wool, None, Some(1.2)),
-
             (leaves, None, Some(0.3)),
             (leaves, Some(Tool::Hoe(ToolMaterial::Wood)), Some(0.15)),
             (leaves, Some(Tool::Hoe(ToolMaterial::Stone)), Some(0.1)),
             (leaves, Some(Tool::Hoe(ToolMaterial::Iron)), Some(0.05)),
             (leaves, Some(Tool::Hoe(ToolMaterial::Diamond)), Some(0.05)),
-
             (leaves2, None, Some(0.3)),
             (leaves2, Some(Tool::Hoe(ToolMaterial::Wood)), Some(0.15)),
             (leaves2, Some(Tool::Hoe(ToolMaterial::Stone)), Some(0.1)),
             (leaves2, Some(Tool::Hoe(ToolMaterial::Iron)), Some(0.05)),
             (leaves2, Some(Tool::Hoe(ToolMaterial::Diamond)), Some(0.05)),
-
             (Block::DeadBush {}, None, Some(0.05)),
             (Block::DeadBush {}, Some(Tool::Shears), Some(0.05)),
-
             (Block::Seagrass {}, None, Some(0.05)),
             (Block::Seagrass {}, Some(Tool::Shears), Some(0.05)),
-
             (tall_seagrass, None, Some(0.05)),
             (tall_seagrass, Some(Tool::Shears), Some(0.05)),
-
             (cocoa, None, Some(0.3)),
             (cocoa, Some(Tool::Axe(ToolMaterial::Wood)), Some(0.15)),
             (cocoa, Some(Tool::Axe(ToolMaterial::Stone)), Some(0.1)),
             (cocoa, Some(Tool::Axe(ToolMaterial::Iron)), Some(0.05)),
             (cocoa, Some(Tool::Axe(ToolMaterial::Diamond)), Some(0.05)),
-
             (Block::MelonBlock {}, None, Some(1.5)),
-            (Block::MelonBlock {}, Some(Tool::Axe(ToolMaterial::Wood)), Some(0.75)),
-            (Block::MelonBlock {}, Some(Tool::Axe(ToolMaterial::Stone)), Some(0.4)),
-            (Block::MelonBlock {}, Some(Tool::Axe(ToolMaterial::Iron)), Some(0.25)),
-            (Block::MelonBlock {}, Some(Tool::Axe(ToolMaterial::Diamond)), Some(0.2)),
-            (Block::MelonBlock {}, Some(Tool::Axe(ToolMaterial::Netherite)), Some(0.2)),
-            (Block::MelonBlock {}, Some(Tool::Axe(ToolMaterial::Gold)), Some(0.15)),
-
+            (
+                Block::MelonBlock {},
+                Some(Tool::Axe(ToolMaterial::Wood)),
+                Some(0.75),
+            ),
+            (
+                Block::MelonBlock {},
+                Some(Tool::Axe(ToolMaterial::Stone)),
+                Some(0.4),
+            ),
+            (
+                Block::MelonBlock {},
+                Some(Tool::Axe(ToolMaterial::Iron)),
+                Some(0.25),
+            ),
+            (
+                Block::MelonBlock {},
+                Some(Tool::Axe(ToolMaterial::Diamond)),
+                Some(0.2),
+            ),
+            (
+                Block::MelonBlock {},
+                Some(Tool::Axe(ToolMaterial::Netherite)),
+                Some(0.2),
+            ),
+            (
+                Block::MelonBlock {},
+                Some(Tool::Axe(ToolMaterial::Gold)),
+                Some(0.15),
+            ),
             (Block::Pumpkin {}, None, Some(1.5)),
-            (Block::Pumpkin {}, Some(Tool::Axe(ToolMaterial::Wood)), Some(0.75)),
-            (Block::Pumpkin {}, Some(Tool::Axe(ToolMaterial::Stone)), Some(0.4)),
-            (Block::Pumpkin {}, Some(Tool::Axe(ToolMaterial::Iron)), Some(0.25)),
-
+            (
+                Block::Pumpkin {},
+                Some(Tool::Axe(ToolMaterial::Wood)),
+                Some(0.75),
+            ),
+            (
+                Block::Pumpkin {},
+                Some(Tool::Axe(ToolMaterial::Stone)),
+                Some(0.4),
+            ),
+            (
+                Block::Pumpkin {},
+                Some(Tool::Axe(ToolMaterial::Iron)),
+                Some(0.25),
+            ),
             (pumpkin_lit, None, Some(1.5)),
             (pumpkin_lit, Some(Tool::Axe(ToolMaterial::Wood)), Some(0.75)),
             (pumpkin_lit, Some(Tool::Axe(ToolMaterial::Stone)), Some(0.4)),
             (pumpkin_lit, Some(Tool::Axe(ToolMaterial::Iron)), Some(0.25)),
-
             // TODO: Fix special sword rules
             //(Block::Web {}, Some(Tool::Sword(ToolMaterial::Wood)), Some(0.4)),
             //(Block::Web {}, Some(Tool::Sword(ToolMaterial::Stone)), Some(0.4)),
@@ -8760,7 +8862,7 @@ impl ToolMaterial {
             ToolMaterial::Gold => 12.0,
             ToolMaterial::Iron => 6.0,
             ToolMaterial::Diamond => 8.0,
-            ToolMaterial::Netherite => 9.0
+            ToolMaterial::Netherite => 9.0,
         }
     }
 }
@@ -8783,7 +8885,7 @@ impl Tool {
             Tool::Shovel(m) => m.get_multiplier(),
             Tool::Hoe(m) => m.get_multiplier(),
             Tool::Sword(_) => 1.5, // TODO: Handle different block values.
-            Tool::Shears => 2.0, // TODO: Handle different block values.
+            Tool::Shears => 2.0,   // TODO: Handle different block values.
         }
     }
 }

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -6513,13 +6513,13 @@ mod tests {
     fn hier_1_12_2() {
         let id_map = VanillaIDMap::new(340);
         assert_eq!(
-            id_map.by_vanilla_id(255 << 4, &HashMap::new()),
+            id_map.by_vanilla_id(255 << 4, Arc::new(RwLock::new(HashMap::new()))),
             StructureBlock {
                 mode: StructureBlockMode::Save
             }
         );
         assert_eq!(
-            id_map.by_vanilla_id((255 << 4) | 3, &HashMap::new()),
+            id_map.by_vanilla_id((255 << 4) | 3, Arc::new(RwLock::new(HashMap::new()))),
             StructureBlock {
                 mode: StructureBlockMode::Data
             }
@@ -6530,13 +6530,13 @@ mod tests {
     fn flat_1_13_2() {
         let id_map = VanillaIDMap::new(404);
         assert_eq!(
-            id_map.by_vanilla_id(8595, &HashMap::new()),
+            id_map.by_vanilla_id(8595, Arc::new(RwLock::new(HashMap::new()))),
             StructureBlock {
                 mode: StructureBlockMode::Save
             }
         );
         assert_eq!(
-            id_map.by_vanilla_id(8598, &HashMap::new()),
+            id_map.by_vanilla_id(8598, Arc::new(RwLock::new(HashMap::new()))),
             StructureBlock {
                 mode: StructureBlockMode::Data
             }
@@ -6547,11 +6547,11 @@ mod tests {
     fn flat_1_14_4() {
         let id_map = VanillaIDMap::new(477);
         assert_eq!(
-            id_map.by_vanilla_id(9113, &HashMap::new()),
+            id_map.by_vanilla_id(9113, Arc::new(RwLock::new(HashMap::new()))),
             Conduit { waterlogged: true }
         );
         assert_eq!(
-            id_map.by_vanilla_id(9114, &HashMap::new()),
+            id_map.by_vanilla_id(9114, Arc::new(RwLock::new(HashMap::new()))),
             Conduit { waterlogged: false }
         );
     }
@@ -6560,11 +6560,11 @@ mod tests {
     fn flat_1_15_1() {
         let id_map = VanillaIDMap::new(575);
         assert_eq!(
-            id_map.by_vanilla_id(9113, &HashMap::new()),
+            id_map.by_vanilla_id(9113, Arc::new(RwLock::new(HashMap::new()))),
             Conduit { waterlogged: true }
         );
         assert_eq!(
-            id_map.by_vanilla_id(9114, &HashMap::new()),
+            id_map.by_vanilla_id(9114, Arc::new(RwLock::new(HashMap::new()))),
             Conduit { waterlogged: false }
         );
     }
@@ -6573,7 +6573,7 @@ mod tests {
     fn flat_1_16() {
         let id_map = VanillaIDMap::new(735);
         assert_eq!(
-            id_map.by_vanilla_id(1048, &HashMap::new()),
+            id_map.by_vanilla_id(1048, Arc::new(RwLock::new(HashMap::new()))),
             NoteBlock {
                 instrument: NoteBlockInstrument::Pling,
                 note: 24,
@@ -6586,7 +6586,7 @@ mod tests {
     fn flat_1_16_2() {
         let id_map = VanillaIDMap::new(751);
         assert_eq!(
-            id_map.by_vanilla_id(1048, &HashMap::new()),
+            id_map.by_vanilla_id(1048, Arc::new(RwLock::new(HashMap::new()))),
             NoteBlock {
                 instrument: NoteBlockInstrument::Pling,
                 note: 24,

--- a/protocol/src/protocol/mod.rs
+++ b/protocol/src/protocol/mod.rs
@@ -1594,6 +1594,10 @@ impl Conn {
             ping,
         ))
     }
+
+    pub fn get_version(&self) -> Version {
+        Version::from_id(self.protocol_version as u32)
+    }
 }
 
 /// Parse a clientbound packet, for debugging packet parsing issues (Conn::read_packet)

--- a/protocol/src/protocol/packet.rs
+++ b/protocol/src/protocol/packet.rs
@@ -3309,7 +3309,7 @@ impl Serializable for CommandNode {
 pub enum DigType {
     StartDestroyBlock,
     AbortDestroyBlock,
-    StopDestroyBlock,
+    FinishDestroyBlock,
     DropAllItems,
     DropItem,
     ReleaseUseItem,
@@ -3321,7 +3321,7 @@ impl DigType {
         match self {
             DigType::StartDestroyBlock => 0,
             DigType::AbortDestroyBlock => 1,
-            DigType::StopDestroyBlock => 2,
+            DigType::FinishDestroyBlock => 2,
             DigType::DropAllItems => 3,
             DigType::DropItem => 4,
             DigType::ReleaseUseItem => 5,
@@ -3335,7 +3335,7 @@ impl From<i32> for DigType {
         match src {
             0 => DigType::StartDestroyBlock,
             1 => DigType::AbortDestroyBlock,
-            2 => DigType::StopDestroyBlock,
+            2 => DigType::FinishDestroyBlock,
             3 => DigType::DropAllItems,
             4 => DigType::DropItem,
             5 => DigType::ReleaseUseItem,

--- a/protocol/src/protocol/packet.rs
+++ b/protocol/src/protocol/packet.rs
@@ -3379,12 +3379,12 @@ impl From<i32> for Hand {
 
 pub fn send_position_look(
     conn: &mut Conn,
-    version: Version,
     position: &Vector3<f64>,
     yaw: f32,
     pitch: f32,
     on_ground: bool,
 ) -> Result<(), Error> {
+    let version = conn.get_version();
     if version >= Version::V1_8 {
         conn.write_packet(
             crate::protocol::packet::play::serverbound::PlayerPositionLook {
@@ -3411,7 +3411,8 @@ pub fn send_position_look(
     }
 }
 
-pub fn send_arm_swing(conn: &mut Conn, version: Version, hand: Hand) -> Result<(), Error> {
+pub fn send_arm_swing(conn: &mut Conn, hand: Hand) -> Result<(), Error> {
+    let version = conn.get_version();
     if version < Version::V1_8 {
         conn.write_packet(packet::play::serverbound::ArmSwing_Handsfree_ID {
             entity_id: 0, // TODO: Check these values!
@@ -3428,11 +3429,11 @@ pub fn send_arm_swing(conn: &mut Conn, version: Version, hand: Hand) -> Result<(
 
 pub fn send_digging(
     conn: &mut Conn,
-    version: Version,
     status: DigType,
     pos: Position,
     face_index: u8,
 ) -> Result<(), Error> {
+    let version = conn.get_version();
     if version < Version::V1_8 {
         conn.write_packet(packet::play::serverbound::PlayerDigging_u8_u8y {
             status: status.ordinal() as u8,
@@ -3458,13 +3459,13 @@ pub fn send_digging(
 
 pub fn send_block_place(
     conn: &mut Conn,
-    version: Version,
     pos: Position,
     face: u8,
     cursor_position: Vector3<f64>,
     hand: Hand,
     item: Box<dyn Fn() -> Option<Stack>>,
 ) -> Result<(), Error> {
+    let version = conn.get_version();
     if version >= Version::V1_14 {
         conn.write_packet(
             packet::play::serverbound::PlayerBlockPlacement_insideblock {
@@ -3523,7 +3524,6 @@ pub fn send_block_place(
 
 pub fn send_client_settings(
     conn: &mut Conn,
-    version: Version,
     locale: String,
     view_distance: u8,
     chat_mode: u8,
@@ -3531,6 +3531,7 @@ pub fn send_client_settings(
     displayed_skin_parts: u8,
     main_hand: Hand,
 ) -> Result<(), Error> {
+    let version = conn.get_version();
     if version < Version::V1_9 {
         // TODO: Do this for protocol version 48
         // 1 snapshot after 1.8
@@ -3553,7 +3554,8 @@ pub fn send_client_settings(
     }
 }
 
-pub fn send_keep_alive(conn: &mut Conn, version: Version, id: i64) -> Result<(), Error> {
+pub fn send_keep_alive(conn: &mut Conn, id: i64) -> Result<(), Error> {
+    let version = conn.get_version();
     if version < Version::V1_8 {
         conn.write_packet(packet::play::serverbound::KeepAliveServerbound_i32 { id: id as i32 })
     } else if version < Version::V1_12 {

--- a/src/entity/block_entity/sign.rs
+++ b/src/entity/block_entity/sign.rs
@@ -63,8 +63,8 @@ pub fn render_sign(
 ) {
     for (mut info, position) in query.iter_mut() {
         if info.dirty {
-            remove_sign(&mut *info);
-            add_sign(renderer.clone(), world.clone(), &mut *info, position);
+            remove_sign(&mut info);
+            add_sign(renderer.clone(), world.clone(), &mut info, position);
         }
         if let Some(model) = &info.model {
             let renderer = renderer.clone();
@@ -82,7 +82,7 @@ pub fn on_add_sign(
     mut query: Query<(&mut SignInfo, &Position), Added<SignInfo>>,
 ) {
     for (mut info, position) in query.iter_mut() {
-        add_sign(renderer.clone(), world.clone(), &mut *info, position);
+        add_sign(renderer.clone(), world.clone(), &mut info, position);
     }
 }
 

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -549,7 +549,7 @@ impl DiggingState {
         let now = std::time::Instant::now();
         let expected = now - self.start;
         let ratio = expected.as_secs_f32() / mining_time.as_secs_f32();
-        return ratio.min(1.0);
+        ratio.min(1.0)
     }
 }
 

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -529,7 +529,7 @@ impl DiggingState {
             Some(mining_time) => {
                 let finish_time = self.start + mining_time;
                 finish_time > std::time::Instant::now()
-            },
+            }
             None => false,
         }
     }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -78,7 +78,13 @@ pub fn add_systems(
             systems::apply_gravity
                 .system()
                 .label(SystemExecStage::Normal),
+        )
+        .add_system(
+            systems::apply_digging
+                .system()
+                .label(SystemExecStage::Normal),
         );
+
     sync.add_system(
         systems::lerp_position
             .system()
@@ -93,12 +99,6 @@ pub fn add_systems(
     )
     .add_system(
         systems::light_entity
-            .system()
-            .label(SystemExecStage::Render)
-            .after(SystemExecStage::Normal),
-    )
-    .add_system(
-        systems::apply_digging
             .system()
             .label(SystemExecStage::Render)
             .after(SystemExecStage::Normal),

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -5,6 +5,7 @@ use crate::ecs::{Manager, SystemExecStage};
 use crate::entity::slime::SlimeModel;
 use crate::entity::zombie::ZombieModel;
 use crate::render::Texture;
+use crate::world::block;
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::*;
 use cgmath::Vector3;
@@ -92,6 +93,12 @@ pub fn add_systems(
     )
     .add_system(
         systems::light_entity
+            .system()
+            .label(SystemExecStage::Render)
+            .after(SystemExecStage::Normal),
+    )
+    .add_system(
+        systems::apply_digging
             .system()
             .label(SystemExecStage::Render)
             .after(SystemExecStage::Normal),
@@ -498,4 +505,77 @@ pub fn resolve_textures(
             height / (texture.get_height() as f32),
         )),
     ]
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiggingState {
+    pub block: block::Block,
+    pub position: shared::Position,
+    pub face: shared::Direction,
+    pub start: std::time::Instant,
+    pub finished: bool,
+}
+
+impl DiggingState {
+    pub fn is_finished(&self) -> bool {
+        // If marked as finished, we don't need to calculate the mining time
+        // again.
+        if self.finished {
+            return true;
+        }
+
+        let mining_time = self.block.get_mining_time(&None);
+        match mining_time {
+            Some(mining_time) => {
+                let finish_time = self.start + mining_time;
+                finish_time > std::time::Instant::now()
+            },
+            None => false,
+        }
+    }
+
+    pub fn get_ratio(&self) -> f32 {
+        // If marked as finished, we don't need to calculate the mining time
+        // again.
+        if self.finished {
+            return 1.0;
+        }
+
+        // TODO: Use in-hand tool
+        let mining_time = self.block.get_mining_time(&None);
+        let mining_time = match mining_time {
+            Some(mining_time) => mining_time,
+            None => return 0.0,
+        };
+        let now = std::time::Instant::now();
+        let expected = now - self.start;
+        let ratio = expected.as_secs_f32() / mining_time.as_secs_f32();
+        return ratio.min(1.0);
+    }
+}
+
+#[derive(Component, Default)]
+pub struct Digging {
+    pub last: Option<DiggingState>,
+    pub current: Option<DiggingState>,
+    pub processed: bool,
+    pub effect: Option<Entity>,
+}
+
+impl Digging {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[derive(Component, Default)]
+pub struct MouseButtons {
+    pub left: bool,
+    pub right: bool,
+}
+
+impl MouseButtons {
+    pub fn new() -> Self {
+        Default::default()
+    }
 }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -517,14 +517,14 @@ pub struct DiggingState {
 }
 
 impl DiggingState {
-    pub fn is_finished(&self) -> bool {
+    pub fn is_finished(&self, tool: &Option<block::Tool>) -> bool {
         // If marked as finished, we don't need to calculate the mining time
         // again.
         if self.finished {
             return true;
         }
 
-        let mining_time = self.block.get_mining_time(&None);
+        let mining_time = self.block.get_mining_time(tool);
         match mining_time {
             Some(mining_time) => {
                 let finish_time = self.start + mining_time;
@@ -534,15 +534,14 @@ impl DiggingState {
         }
     }
 
-    pub fn get_ratio(&self) -> f32 {
+    pub fn get_ratio(&self, tool: &Option<block::Tool>) -> f32 {
         // If marked as finished, we don't need to calculate the mining time
         // again.
         if self.finished {
             return 1.0;
         }
 
-        // TODO: Use in-hand tool
-        let mining_time = self.block.get_mining_time(&None);
+        let mining_time = self.block.get_mining_time(tool);
         let mining_time = match mining_time {
             Some(mining_time) => mining_time,
             None => return 0.0,

--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -181,7 +181,7 @@ fn update_render_players(
         use std::f64::consts::PI as PI64;
 
         if player_model.dirty {
-            add_player(renderer.clone(), &mut *player_model);
+            add_player(renderer.clone(), &mut player_model);
         }
 
         if let Some(pmodel) = &player_model.model {
@@ -332,7 +332,7 @@ pub fn player_added(
     mut query: Query<&mut PlayerModel, Added<PlayerModel>>,
 ) {
     for mut player_model in query.iter_mut() {
-        add_player(renderer.clone(), &mut *player_model);
+        add_player(renderer.clone(), &mut player_model);
     }
 }
 
@@ -716,13 +716,13 @@ pub fn handle_movement(
                 // effect when pushing up against walls.
 
                 let (bounds, xhit) =
-                    check_collisions(&**world, &mut position, &last_position, player_bounds);
+                    check_collisions(&world, &mut position, &last_position, player_bounds);
                 position.position.x = bounds.min.x + 0.3;
                 last_position.x = position.position.x;
 
                 position.position.z = target.z;
                 let (bounds, zhit) =
-                    check_collisions(&**world, &mut position, &last_position, player_bounds);
+                    check_collisions(&world, &mut position, &last_position, player_bounds);
                 position.position.z = bounds.min.z + 0.3;
                 last_position.z = position.position.z;
 
@@ -744,7 +744,7 @@ pub fn handle_movement(
                             0.0,
                         ));
                         let (_, hit) =
-                            check_collisions(&**world, &mut position, &last_position, mini);
+                            check_collisions(&world, &mut position, &last_position, mini);
                         if !hit {
                             target.y += offset as f64 / 16.0;
                             ox = target.x;
@@ -758,7 +758,7 @@ pub fn handle_movement(
 
                 position.position.y = target.y;
                 let (bounds, yhit) =
-                    check_collisions(&**world, &mut position, &last_position, player_bounds);
+                    check_collisions(&world, &mut position, &last_position, player_bounds);
                 position.position.y = bounds.min.y;
                 last_position.y = position.position.y;
                 if yhit {
@@ -770,7 +770,7 @@ pub fn handle_movement(
                         Aabb3::new(Point3::new(-0.3, -0.005, -0.3), Point3::new(0.3, 0.0, 0.3));
                     let prev = gravity.on_ground;
                     let (_, hit) =
-                        check_collisions(&**world, &mut position, &last_position, ground);
+                        check_collisions(&world, &mut position, &last_position, ground);
                     gravity.on_ground = hit;
                     if !prev && gravity.on_ground {
                         movement.did_touch_ground = true;

--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -1,5 +1,6 @@
 use super::{
-    Bounds, GameInfo, Gravity, Light, Position, Rotation, TargetPosition, TargetRotation, Velocity, Digging, MouseButtons
+    Bounds, Digging, GameInfo, Gravity, Light, MouseButtons, Position, Rotation, TargetPosition,
+    TargetRotation, Velocity,
 };
 use crate::ecs::{Manager, SystemExecStage};
 use crate::entity::slime::{added_slime, update_slime};
@@ -769,8 +770,7 @@ pub fn handle_movement(
                     let ground =
                         Aabb3::new(Point3::new(-0.3, -0.005, -0.3), Point3::new(0.3, 0.0, 0.3));
                     let prev = gravity.on_ground;
-                    let (_, hit) =
-                        check_collisions(&world, &mut position, &last_position, ground);
+                    let (_, hit) = check_collisions(&world, &mut position, &last_position, ground);
                     gravity.on_ground = hit;
                     if !prev && gravity.on_ground {
                         movement.did_touch_ground = true;

--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -1,5 +1,5 @@
 use super::{
-    Bounds, GameInfo, Gravity, Light, Position, Rotation, TargetPosition, TargetRotation, Velocity,
+    Bounds, GameInfo, Gravity, Light, Position, Rotation, TargetPosition, TargetRotation, Velocity, Digging, MouseButtons
 };
 use crate::ecs::{Manager, SystemExecStage};
 use crate::entity::slime::{added_slime, update_slime};
@@ -95,6 +95,8 @@ pub fn create_local(m: &mut Manager) -> Entity {
         )))
         .insert(PlayerModel::new("", false, false, true))
         .insert(Light::new())
+        .insert(Digging::new())
+        .insert(MouseButtons::new())
         .insert(EntityType::Player);
     entity.id()
 }

--- a/src/entity/systems.rs
+++ b/src/entity/systems.rs
@@ -271,8 +271,8 @@ impl ApplyDigging<'_, '_> {
             position: Vector3::new(pos.x as f64, pos.y as f64, pos.z as f64),
             status: -1,
         });
+        entity.insert(crate::particle::ParticleType::BlockBreak);
         effect.replace(entity.id());
-        //ParticleType::BlockBreak.create_particle(&self.commands, entity);
     }
 
     fn abort_digging(&mut self, state: &DiggingState, effect: &mut Option<Entity>) {

--- a/src/entity/systems.rs
+++ b/src/entity/systems.rs
@@ -119,7 +119,7 @@ pub fn light_entity(
 pub fn apply_digging(
     renderer: Res<Arc<crate::render::Renderer>>,
     world: Res<Arc<crate::world::World>>,
-    conn: Res<Arc<RwLock<Option<protocol::Conn>>>>,
+    network: Res<crate::server::Network>,
     commands: Commands,
     mut query: Query<(&MouseButtons, &mut Digging)>,
     mut effect_query: Query<&mut BlockBreakEffect>,
@@ -134,8 +134,7 @@ pub fn apply_digging(
         test_block,
     );
 
-    let version = Version::from_id(world.protocol_version as u32);
-    let mut system = ApplyDigging::new(target, conn.clone(), commands, version);
+    let mut system = ApplyDigging::new(target, network.conn.clone(), commands, network.version);
     for (mouse_buttons, mut digging) in query.iter_mut() {
         if let Some(effect) = digging.effect {
             if let Ok(mut effect) = effect_query.get_mut(effect) {

--- a/src/entity/systems.rs
+++ b/src/entity/systems.rs
@@ -142,7 +142,7 @@ pub fn apply_digging(
         let hotbar_index = inventory.hotbar_index;
         let inventory = inventory.player_inventory.read();
         let item = inventory.get_item(36 + hotbar_index as u16);
-        item.map(|i| i.material.as_tool()).flatten()
+        item.and_then(|i| i.material.as_tool())
     };
 
     let mut system = ApplyDigging::new(

--- a/src/entity/systems.rs
+++ b/src/entity/systems.rs
@@ -220,11 +220,12 @@ impl ApplyDigging<'_, '_> {
             _ => {},
         }
 
-        if let Some(effect) = effect {
+        if let Some(current) = &digging.current {
             // Update the block break animation progress.
-            if let Some(current) = &digging.current {
+            if let Some(effect) = effect {
                 effect.update_ratio(current.get_ratio(&self.tool));
             }
+            self.swing_arm();
         }
     }
 
@@ -299,6 +300,15 @@ impl ApplyDigging<'_, '_> {
             status,
             state.position,
             state.face.index() as u8
+        ).unwrap();
+    }
+
+    fn swing_arm(&self) {
+        let mut conn = self.conn.write();
+        packet::send_arm_swing(
+            conn.as_mut().unwrap(),
+            self.version,
+            packet::Hand::MainHand,
         ).unwrap();
     }
 }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -14,6 +14,7 @@ use crate::ui::Container;
 use leafish_protocol::format::Component;
 use leafish_protocol::item::Stack;
 use leafish_protocol::protocol::Version;
+use leafish_blocks as block;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -1693,5 +1694,48 @@ impl Material {
             }
         }
         (format!("items/{}", result), format!("blocks/{}", result))
+    }
+
+    pub fn as_tool(&self) -> Option<block::Tool> {
+        use block::{Tool, ToolMaterial};
+        match *self {
+            Material::WoodPickaxe => Some(Tool::Pickaxe(ToolMaterial::Wood)),
+            Material::StonePickaxe => Some(Tool::Pickaxe(ToolMaterial::Stone)),
+            Material::GoldPickaxe => Some(Tool::Pickaxe(ToolMaterial::Gold)),
+            Material::IronPickaxe => Some(Tool::Pickaxe(ToolMaterial::Iron)),
+            Material::DiamondPickaxe => Some(Tool::Pickaxe(ToolMaterial::Diamond)),
+            Material::NetheritePickaxe => Some(Tool::Pickaxe(ToolMaterial::Netherite)),
+
+            Material::WoodAxe => Some(Tool::Axe(ToolMaterial::Wood)),
+            Material::StoneAxe => Some(Tool::Axe(ToolMaterial::Stone)),
+            Material::GoldAxe => Some(Tool::Axe(ToolMaterial::Gold)),
+            Material::IronAxe => Some(Tool::Axe(ToolMaterial::Iron)),
+            Material::DiamondAxe => Some(Tool::Axe(ToolMaterial::Diamond)),
+            Material::NetheriteAxe => Some(Tool::Axe(ToolMaterial::Netherite)),
+
+            Material::WoodSpade => Some(Tool::Shovel(ToolMaterial::Wood)),
+            Material::StoneSpade => Some(Tool::Shovel(ToolMaterial::Stone)),
+            Material::GoldSpade => Some(Tool::Shovel(ToolMaterial::Gold)),
+            Material::IronSpade => Some(Tool::Shovel(ToolMaterial::Iron)),
+            Material::DiamondSpade => Some(Tool::Shovel(ToolMaterial::Diamond)),
+            Material::NetheriteShovel => Some(Tool::Shovel(ToolMaterial::Netherite)),
+
+            Material::WoodHoe => Some(Tool::Hoe(ToolMaterial::Wood)),
+            Material::StoneHoe => Some(Tool::Hoe(ToolMaterial::Stone)),
+            Material::GoldHoe => Some(Tool::Hoe(ToolMaterial::Gold)),
+            Material::IronHoe => Some(Tool::Hoe(ToolMaterial::Iron)),
+            Material::DiamondHoe => Some(Tool::Hoe(ToolMaterial::Diamond)),
+            Material::NetheriteHoe => Some(Tool::Hoe(ToolMaterial::Netherite)),
+
+            Material::WoodSword => Some(Tool::Sword(ToolMaterial::Wood)),
+            Material::StoneSword => Some(Tool::Sword(ToolMaterial::Stone)),
+            Material::GoldSword => Some(Tool::Sword(ToolMaterial::Gold)),
+            Material::IronSword => Some(Tool::Sword(ToolMaterial::Iron)),
+            Material::DiamondSword => Some(Tool::Sword(ToolMaterial::Diamond)),
+            Material::NetheriteSword => Some(Tool::Sword(ToolMaterial::Netherite)),
+
+            Material::Shears => Some(Tool::Shears),
+            _ => None,
+        }
     }
 }

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -11,10 +11,10 @@ use crate::render::inventory::InventoryWindow;
 use crate::render::Renderer;
 use crate::screen::ScreenSystem;
 use crate::ui::Container;
+use leafish_blocks as block;
 use leafish_protocol::format::Component;
 use leafish_protocol::item::Stack;
 use leafish_protocol::protocol::Version;
-use leafish_blocks as block;
 use parking_lot::RwLock;
 use std::sync::Arc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,8 +295,7 @@ fn main() {
 
     let textures = renderer.get_textures();
     let default_protocol_version = protocol::versions::protocol_name_to_protocol_version(
-        opt.default_protocol_version
-            .unwrap_or_else(|| "".to_string()),
+        opt.default_protocol_version.unwrap_or_default(),
     );
 
     #[cfg(target_os = "linux")]

--- a/src/particle/block_break_effect.rs
+++ b/src/particle/block_break_effect.rs
@@ -50,7 +50,7 @@ impl BlockBreakEffect {
 
     pub fn update_ratio(&mut self, ratio: f32) {
         // 0.0 - 1.0
-        let anim_id = ((ratio * 10.0) as i8 - 1).max(0);
+        let anim_id = ((ratio * 10.0) as i8 + 1).min(10);
         self.update(anim_id);
     }
 }

--- a/src/particle/block_break_effect.rs
+++ b/src/particle/block_break_effect.rs
@@ -73,7 +73,7 @@ pub fn effect_added(
 pub fn effect_updated(renderer: Res<Arc<Renderer>>, mut query: Query<&mut BlockBreakEffect>) {
     for mut effect in query.iter_mut() {
         if effect.dirty {
-            readd_model(renderer.clone(), &mut *effect);
+            readd_model(renderer.clone(), &mut effect);
             effect.dirty = false;
         }
         if let Some(model) = &effect.model {
@@ -103,7 +103,7 @@ fn readd_model(renderer: Arc<Renderer>, effect: &mut BlockBreakEffect) {
         let mut model = vec![];
         let tex = render::Renderer::get_texture(
             renderer.get_textures_ref(),
-            &*format!("blocks/destroy_stage_{}", effect.status - 1),
+            &format!("blocks/destroy_stage_{}", effect.status - 1),
         );
         model::append_box(
             &mut model,

--- a/src/particle/mod.rs
+++ b/src/particle/mod.rs
@@ -1,4 +1,3 @@
-use crate::ecs::Manager;
 use bevy_ecs::prelude::*;
 
 pub mod block_break_effect;
@@ -9,39 +8,4 @@ pub struct EntityMetadata(pub Entity);
 #[derive(Component, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum ParticleType {
     BlockBreak,
-}
-
-impl ParticleType {
-    pub fn create_particle(&self, m: &mut Manager, entity: Entity) {
-        if self.supported() {
-            self.create_particle_internally(m, entity);
-            self.create_model(m, entity);
-        }
-    }
-
-    pub fn create_particle_custom_model(&self, m: &mut Manager, entity: Entity) {
-        if self.supported() {
-            self.create_particle_internally(m, entity);
-        }
-    }
-
-    fn create_particle_internally(&self, m: &mut Manager, entity: Entity) {
-        m.world.entity_mut(entity).insert(*self);
-    }
-
-    #[allow(unreachable_patterns)] // this pattern will be reachable in the future, so just ignore the warning for now
-    #[allow(clippy::single_match)]
-    fn create_model(&self, _m: &mut Manager, _entity: Entity) {
-        match self {
-            ParticleType::BlockBreak => {
-                /*let effect = BlockBreakEffect::new(m, metadata);
-                m.add_component_direct(entity, effect);*/
-            }
-            _ => {}
-        };
-    }
-
-    fn supported(&self) -> bool {
-        matches!(self, ParticleType::BlockBreak)
-    }
 }

--- a/src/render/hud.rs
+++ b/src/render/hud.rs
@@ -1116,10 +1116,7 @@ impl Hud {
 
             let mut component_lines = 0;
             for message in messages.iter().take(cmp::min(10, history_size)).enumerate() {
-                let lines = (renderer
-                    .ui
-                    .lock()
-                    .size_of_string(&message.1 .1.to_string())
+                let lines = (renderer.ui.lock().size_of_string(&message.1 .1.to_string())
                     / (CHAT_WIDTH * scale))
                     .ceil() as u8;
                 let transparency = if message.1 .0 >= FADE_OUT_START_TICKS {

--- a/src/render/hud.rs
+++ b/src/render/hud.rs
@@ -1091,7 +1091,7 @@ impl Hud {
 
             let mut component_lines = 0;
             for message in messages.iter().take(cmp::min(10, history_size)) {
-                let lines = (renderer.ui.lock().size_of_string(&*message.1.to_string())
+                let lines = (renderer.ui.lock().size_of_string(&message.1.to_string())
                     / (CHAT_WIDTH * scale))
                     .ceil() as u8;
                 component_lines += lines;
@@ -1119,7 +1119,7 @@ impl Hud {
                 let lines = (renderer
                     .ui
                     .lock()
-                    .size_of_string(&*message.1 .1.to_string())
+                    .size_of_string(&message.1 .1.to_string())
                     / (CHAT_WIDTH * scale))
                     .ceil() as u8;
                 let transparency = if message.1 .0 >= FADE_OUT_START_TICKS {
@@ -1157,7 +1157,7 @@ impl Hud {
         let icon_scale = Hud::icon_scale(renderer.clone());
         let textures = item.material.texture_locations();
         let texture =
-            if let Some(tex) = Renderer::get_texture_optional(&renderer.textures, &*textures.0) {
+            if let Some(tex) = Renderer::get_texture_optional(&renderer.textures, &textures.0) {
                 if tex.dummy {
                     textures.1
                 } else {

--- a/src/render/inventory.rs
+++ b/src/render/inventory.rs
@@ -155,7 +155,7 @@ impl InventoryWindow {
         let icon_scale = Hud::icon_scale(renderer.clone());
         let textures = item.material.texture_locations();
         let texture =
-            if let Some(tex) = Renderer::get_texture_optional(&renderer.textures, &*textures.0) {
+            if let Some(tex) = Renderer::get_texture_optional(&renderer.textures, &textures.0) {
                 if tex.dummy {
                     textures.1
                 } else {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -326,7 +326,7 @@ impl Manager {
                 Self::add_task(
                     &progress_info,
                     "Downloading Asset Index",
-                    &*location.to_string_lossy(),
+                    &location.to_string_lossy(),
                     length,
                 );
                 let tmp_file = paths::get_cache_dir().join(format!("index-{}.tmp", ASSET_VERSION));
@@ -351,7 +351,7 @@ impl Manager {
             Self::add_task(
                 &progress_info,
                 "Downloading Assets",
-                &*root_location.to_string_lossy(),
+                &root_location.to_string_lossy(),
                 objects.len() as u64,
             );
             for (k, v) in objects {
@@ -386,7 +386,7 @@ impl Manager {
                 Self::add_task_progress(
                     &progress_info,
                     "Downloading Assets",
-                    &*root_location.to_string_lossy(),
+                    &root_location.to_string_lossy(),
                     1,
                 );
             }
@@ -529,7 +529,7 @@ impl ObjectPack {
     fn new() -> ObjectPack {
         let loc = paths::get_data_dir().join(format!("index/{}.json", ASSET_VERSION));
         let location = path::Path::new(&loc);
-        let file = fs::File::open(&location).unwrap();
+        let file = fs::File::open(location).unwrap();
         let index: serde_json::Value = serde_json::from_reader(&file).unwrap();
         let objects = index.get("objects").and_then(|v| v.as_object()).unwrap();
         let mut hash_objs = HashMap::with_hasher(BuildHasherDefault::default());

--- a/src/screen/background.rs
+++ b/src/screen/background.rs
@@ -44,7 +44,7 @@ impl Screen for Background {
         let path = self.vars.get(BACKGROUND_IMAGE);
         self.last_path = (*path).clone();
         let background =
-            if Renderer::get_texture_optional(renderer.get_textures_ref(), &*format!("#{}", path))
+            if Renderer::get_texture_optional(renderer.get_textures_ref(), &format!("#{}", path))
                 .is_some()
             {
                 Some(

--- a/src/screen/chat.rs
+++ b/src/screen/chat.rs
@@ -208,7 +208,7 @@ impl super::Screen for Chat {
                     .text("_")
                     .alignment(VAttach::Bottom, HAttach::Left)
                     .position(
-                        renderer.ui.lock().size_of_string(&*self.written) + 2.0 * scale,
+                        renderer.ui.lock().size_of_string(&self.written) + 2.0 * scale,
                         2.0 * scale,
                     )
                     .create(ui_container),
@@ -227,7 +227,7 @@ impl super::Screen for Chat {
                         .text("_")
                         .alignment(VAttach::Bottom, HAttach::Left)
                         .position(
-                            renderer.ui.lock().size_of_string(&*self.written) + 2.0 * scale,
+                            renderer.ui.lock().size_of_string(&self.written) + 2.0 * scale,
                             2.0 * scale,
                         )
                         .create(ui_container),
@@ -358,7 +358,7 @@ impl Chat {
         let mut component_lines = 0;
         for i in 0..cmp::min(10, history_size) {
             let message = self.context.messages.clone().read()[history_size - 1 - i].clone();
-            let lines = (renderer.ui.lock().size_of_string(&*message.1.to_string())
+            let lines = (renderer.ui.lock().size_of_string(&message.1.to_string())
                 / (hud::CHAT_WIDTH * scale))
                 .ceil() as u8;
             component_lines += lines;
@@ -397,7 +397,7 @@ impl Chat {
         let mut component_lines = 0;
         for i in 0..cmp::min(10, history_size) {
             let message = self.context.messages.clone().read()[history_size - 1 - i].clone();
-            let lines = (renderer.ui.lock().size_of_string(&*message.1.to_string())
+            let lines = (renderer.ui.lock().size_of_string(&message.1.to_string())
                 / (hud::CHAT_WIDTH * scale))
                 .ceil() as u8;
             let text = ui::FormattedBuilder::new()

--- a/src/screen/launcher.rs
+++ b/src/screen/launcher.rs
@@ -149,7 +149,7 @@ impl super::Screen for Launcher {
                                 accounts.lock().push(account);
                             }
                             screen_sys.pop_screen();
-                            save_accounts(&*accounts.lock());
+                            save_accounts(&accounts.lock());
                         }),
                         game.vars.clone(),
                     )));
@@ -220,7 +220,7 @@ impl super::Screen for Launcher {
                     if client_token.is_empty() {
                         client_token = std::iter::repeat(())
                             .map(|()| {
-                                rand::thread_rng().sample(&rand::distributions::Alphanumeric)
+                                rand::thread_rng().sample(rand::distributions::Alphanumeric)
                                     as char
                             })
                             .take(20)
@@ -232,7 +232,7 @@ impl super::Screen for Launcher {
                         .get(&account.account_type)
                         .unwrap()
                         .value()
-                        .refresh(account.clone(), &*client_token);
+                        .refresh(account.clone(), &client_token);
                     if result.is_ok() {
                         active_account.clone().lock().replace(result.ok().unwrap());
                         game.screen_sys
@@ -265,7 +265,7 @@ impl super::Screen for Launcher {
                                     match account {
                                         Ok(account) => {
                                             drop(std::mem::replace(&mut (*accounts)[idx], account));
-                                            save_accounts(&*accounts);
+                                            save_accounts(&accounts);
                                         }
                                         Err(err) => {
                                             println!(
@@ -391,7 +391,7 @@ impl super::Screen for Launcher {
                                 match account {
                                     Ok(account) => {
                                         drop(std::mem::replace(&mut (*accounts)[idx], account));
-                                        save_accounts(&*accounts);
+                                        save_accounts(&accounts);
                                     }
                                     Err(err) => {
                                         println!(
@@ -488,7 +488,7 @@ pub fn load_accounts() -> Option<Vec<Account>> {
     if let Ok(mut file) = fs::File::open(paths::get_config_dir().join("accounts.cfg")) {
         let mut content = String::new();
         file.read_to_string(&mut content).unwrap();
-        let accounts: Option<Vec<Account>> = serde_json::from_str(&*content).ok();
+        let accounts: Option<Vec<Account>> = serde_json::from_str(&content).ok();
         return accounts;
     }
     None

--- a/src/screen/launcher.rs
+++ b/src/screen/launcher.rs
@@ -220,8 +220,7 @@ impl super::Screen for Launcher {
                     if client_token.is_empty() {
                         client_token = std::iter::repeat(())
                             .map(|()| {
-                                rand::thread_rng().sample(rand::distributions::Alphanumeric)
-                                    as char
+                                rand::thread_rng().sample(rand::distributions::Alphanumeric) as char
                             })
                             .take(20)
                             .collect();

--- a/src/screen/login.rs
+++ b/src/screen/login.rs
@@ -218,7 +218,7 @@ impl super::Screen for Login {
             // Generate random token if it wasn't supplied
             if client_token.is_empty() {
                 client_token = std::iter::repeat(())
-                    .map(|()| rand::thread_rng().sample(&rand::distributions::Alphanumeric) as char)
+                    .map(|()| rand::thread_rng().sample(rand::distributions::Alphanumeric) as char)
                     .take(20)
                     .collect();
                 self.vars.set(auth::AUTH_CLIENT_TOKEN, client_token);
@@ -325,12 +325,12 @@ fn try_login_account(
     };
     if refresh && (account.name.is_empty() || password.is_empty()) {
         // password is at idx 1 in the verification tokens
-        account.refresh(&*client_token)
+        account.refresh(&client_token)
     } else {
         Account::login(
             account.verification_tokens.get(0).unwrap(),
             password,
-            &*client_token,
+            &client_token,
             account.account_type,
         )
     }

--- a/src/screen/server_list.rs
+++ b/src/screen/server_list.rs
@@ -625,7 +625,7 @@ impl super::Screen for ServerList {
                         if let Some(favicon) = res.favicon {
                             let name: String = std::iter::repeat(())
                                 .map(|()| {
-                                    rand::thread_rng().sample(&rand::distributions::Alphanumeric)
+                                    rand::thread_rng().sample(rand::distributions::Alphanumeric)
                                         as char
                                 })
                                 .take(30)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -785,7 +785,7 @@ impl Server {
                                 .write()
                                 .disconnect_reason
                                 .replace(Component::new(format::ComponentType::new(
-                                    &*format!("An error occurred while reading a packet: {}", err),
+                                    &format!("An error occurred while reading a packet: {}", err),
                                     None,
                                 )));
                         }
@@ -1238,7 +1238,6 @@ impl Server {
                     .unwrap();
                 mouse_buttons.left = false;
                 mouse_buttons.right = false;
-                return;
             }
         }
     }
@@ -1628,7 +1627,7 @@ impl Server {
         }
 
         let entity_id = self.player.read().unwrap().0;
-        let local_player = create_local(&mut *self.entities.clone().write());
+        let local_player = create_local(&mut self.entities.clone().write());
         *self.player.clone().write() = Some((entity_id, local_player));
         let gamemode = GameMode::from_int((respawn.gamemode & 0x7) as i32);
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -759,8 +759,8 @@ impl Server {
                                     ),
                                     status: block_break.stage,
                                 });
+                                entity.insert(crate::particle::ParticleType::BlockBreak);
                                 let entity = entity.id();
-                                //ParticleType::BlockBreak.create_particle(&mut entities.world, entity);
                                 server
                                     .active_block_break_anims
                                     .clone()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,7 @@
 use crate::ecs::Manager;
 use crate::entity;
 use crate::entity::player::{create_local, PlayerModel, PlayerMovement};
-use crate::entity::{EntityType, GameInfo, Gravity, TargetPosition, TargetRotation, MouseButtons};
+use crate::entity::{EntityType, GameInfo, Gravity, MouseButtons, TargetPosition, TargetRotation};
 use crate::format;
 use crate::inventory::material::versions::to_material;
 use crate::inventory::{inventory_from_type, Inventory, InventoryContext, InventoryType, Item};
@@ -867,11 +867,12 @@ impl Server {
         let mut parallel = SystemStage::parallel();
         let mut sync = SystemStage::single_threaded();
         let mut entity_sched = SystemStage::single_threaded();
+        let network = Network::new(conn.clone(), mapped_protocol_version);
         entities.world.insert_resource(entity::GameInfo::new());
         entities.world.insert_resource(world.clone());
         entities.world.insert_resource(renderer.clone());
         entities.world.insert_resource(screen_sys.clone());
-        entities.world.insert_resource(Network::new(conn.clone(), mapped_protocol_version));
+        entities.world.insert_resource(network);
         entities.world.insert_resource(inventory_context.clone());
         entity::add_systems(&mut entities, &mut parallel, &mut sync, &mut entity_sched);
         entities
@@ -2485,9 +2486,6 @@ pub struct Network {
 
 impl Network {
     pub fn new(conn: Arc<RwLock<Option<protocol::Conn>>>, version: Version) -> Self {
-        Self {
-            conn,
-            version,
-        }
+        Self { conn, version }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,12 +15,11 @@
 use crate::ecs::Manager;
 use crate::entity;
 use crate::entity::player::{create_local, PlayerModel, PlayerMovement};
-use crate::entity::{EntityType, GameInfo, Gravity, TargetPosition, TargetRotation};
+use crate::entity::{EntityType, GameInfo, Gravity, TargetPosition, TargetRotation, MouseButtons};
 use crate::format;
 use crate::inventory::material::versions::to_material;
 use crate::inventory::{inventory_from_type, Inventory, InventoryContext, InventoryType, Item};
 use crate::particle::block_break_effect::{BlockBreakEffect, BlockEffectData};
-use crate::particle::ParticleType;
 use crate::protocol::{self, forge, mapped_packet, packet};
 use crate::render;
 use crate::render::hud::HudContext;
@@ -49,9 +48,8 @@ use leafish_protocol::item::Stack;
 use leafish_protocol::protocol::login::Account;
 use leafish_protocol::protocol::mapped_packet::MappablePacket;
 use leafish_protocol::protocol::mapped_packet::MappedPacket;
-use leafish_protocol::protocol::packet::{DigType, Hand};
+use leafish_protocol::protocol::packet::Hand;
 use leafish_protocol::protocol::{Conn, Version};
-use leafish_shared::direction::Direction as BlockDirection;
 use log::{debug, error, info, warn};
 use parking_lot::Mutex;
 use parking_lot::RwLock;
@@ -111,8 +109,6 @@ pub struct Server {
     version: AtomicUsize,
 
     // Entity accessors
-    block_break_info: Mutex<BlockBreakInfo>,
-    //
     pub player: Arc<RwLock<Option<(i32, Entity)>>>,
     entity_map: Arc<RwLock<HashMap<i32, Entity, BuildHasherDefault<FNVHash>>>>,
     players: Arc<RwLock<HashMap<protocol::UUID, PlayerInfo, BuildHasherDefault<FNVHash>>>>,
@@ -137,18 +133,6 @@ pub struct Server {
     screen_sys: Arc<ScreenSystem>,
     renderer: Arc<Renderer>,
     active_block_break_anims: Arc<DashMap<i32, Entity>>,
-}
-
-#[derive(Debug)]
-pub struct BlockBreakInfo {
-    break_position: Position,
-    break_face: BlockDirection,
-    hardness: f32,
-    progress: f32,
-    delay: u8,
-    active: bool,
-    pressed: bool,
-    effect_id: Option<Entity>,
 }
 
 #[derive(Debug)]
@@ -776,7 +760,7 @@ impl Server {
                                     status: block_break.stage,
                                 });
                                 let entity = entity.id();
-                                ParticleType::BlockBreak.create_particle(&mut entities, entity);
+                                //ParticleType::BlockBreak.create_particle(&mut entities.world, entity);
                                 server
                                     .active_block_break_anims
                                     .clone()
@@ -881,6 +865,7 @@ impl Server {
         entities.world.insert_resource(world.clone());
         entities.world.insert_resource(renderer.clone());
         entities.world.insert_resource(screen_sys.clone());
+        entities.world.insert_resource(conn.clone());
         entity::add_systems(&mut entities, &mut parallel, &mut sync, &mut entity_sched);
         entities
             .schedule
@@ -942,16 +927,6 @@ impl Server {
             fps_start: RwLock::new(0),
             dead: AtomicBool::new(false),
             just_died: AtomicBool::new(false),
-            block_break_info: Mutex::new(BlockBreakInfo {
-                break_position: Default::default(),
-                break_face: BlockDirection::Invalid,
-                hardness: 0.0,
-                progress: 0.0,
-                delay: 0,
-                active: false,
-                pressed: false,
-                effect_id: None,
-            }),
             last_chat_open: AtomicBool::new(false),
             chat_open: AtomicBool::new(false),
             chat_ctx: Arc::new(ChatContext::new()),
@@ -1205,9 +1180,9 @@ impl Server {
     #[allow(unused_must_use)]
     pub fn minecraft_tick(&self, game: &mut Game) {
         if let Some(player) = *self.player.read() {
+            let entities = self.entities.clone();
+            let mut entities = entities.write();
             let on_ground = {
-                let entities = self.entities.clone();
-                let mut entities = entities.write();
                 let mut movement = entities
                     .world
                     .entity_mut(player.1)
@@ -1224,14 +1199,12 @@ impl Server {
                 }
             }
             .unwrap_or_else(|| {
-                self.entities
-                    .read()
+                entities
                     .world
                     .entity(player.1)
                     .get::<Gravity>()
                     .map_or(false, |v| v.on_ground)
             });
-            let entities = self.entities.read();
 
             let position = entities
                 .world
@@ -1255,110 +1228,18 @@ impl Server {
                 on_ground,
             )
             .map_err(|_| self.disconnect_closed(None));
-        }
-        if !game.focused {
-            if self.block_break_info.lock().pressed {
-                self.abort_breaking(true);
-            }
-            return;
-        }
-        let break_delay = self.block_break_info.lock().delay;
-        if break_delay > 0 {
-            if !self.reeval_target_block() {
-                self.block_break_info.lock().delay -= 1;
-            }
-        } else if self.block_break_info.lock().active {
-            if !self.reeval_target_block() {
-                if self.block_break_info.lock().progress >= 1.0 {
-                    let face_idx = self.block_break_info.lock().break_face.index() as u8;
-                    packet::send_digging(
-                        self.conn.clone().write().as_mut().unwrap(),
-                        self.mapped_protocol_version,
-                        DigType::StopDestroyBlock,
-                        self.block_break_info.lock().break_position,
-                        face_idx,
-                    )
-                    .map_err(|_| self.disconnect_closed(None));
-                    self.block_break_info.lock().active = false;
-                    self.block_break_info.lock().delay = 5;
-                    if let Some(break_id) = self.block_break_info.lock().effect_id.take() {
-                        self.entities.clone().write().world.despawn(break_id);
-                    }
-                } else {
-                    packet::send_arm_swing(
-                        self.conn.clone().write().as_mut().unwrap(),
-                        self.mapped_protocol_version,
-                        Hand::MainHand,
-                    )
-                    .map_err(|_| self.disconnect_closed(None));
-                    self.block_break_info.lock().progress += 0.1; // TODO: Make this value meaningful
-                    let anim_ent = self.block_break_info.lock().effect_id.unwrap();
-                    let entities = self.entities.clone();
-                    let mut entities = entities.write();
-                    let mut anim = entities.world.get_entity_mut(anim_ent).unwrap();
-                    let effect = anim.get_mut::<BlockBreakEffect>();
-                    if let Some(mut effect) = effect {
-                        effect.update_ratio(self.block_break_info.lock().progress);
-                    }
-                }
-            }
-        } else if self.block_break_info.lock().pressed {
-            self.on_left_click();
-        }
-    }
 
-    #[allow(unused_must_use)]
-    fn reeval_target_block(&self) -> bool {
-        if let Some((pos, _, face, _)) = target::trace_ray(
-            &self.world.clone(),
-            4.0,
-            self.renderer.camera.lock().pos.to_vec(),
-            self.renderer.view_vector.lock().cast().unwrap(),
-            target::test_block,
-        ) {
-            let break_pos = self.block_break_info.lock().break_position;
-            let break_face = self.block_break_info.lock().break_face;
-            if pos != break_pos || face != break_face {
-                packet::send_digging(
-                    self.conn.clone().write().as_mut().unwrap(),
-                    self.mapped_protocol_version,
-                    DigType::AbortDestroyBlock,
-                    break_pos,
-                    break_face.index() as u8,
-                )
-                .map_err(|_| self.disconnect_closed(None));
-                packet::send_digging(
-                    self.conn.clone().write().as_mut().unwrap(),
-                    self.mapped_protocol_version,
-                    DigType::StartDestroyBlock,
-                    pos,
-                    face.index() as u8,
-                )
-                .map_err(|_| self.disconnect_closed(None));
-                self.block_break_info.lock().break_position = pos;
-                self.block_break_info.lock().break_face = face;
-                self.block_break_info.lock().progress = 0.0;
-                self.block_break_info.lock().hardness = 1.0; // TODO: Get actual hardness values depending on blocktype and version and tool in hands
-                if let Some(break_id) = self.block_break_info.lock().effect_id.take() {
-                    self.entities.clone().write().world.despawn(break_id);
-                }
-
-                let entities = self.entities.clone();
-                let mut entities = entities.write();
-                let mut entity = entities.world.spawn();
-                entity.insert(BlockEffectData {
-                    position: Vector3::new(pos.x as f64, pos.y as f64, pos.z as f64),
-                    status: -1,
-                });
-                let entity = entity.id();
-                ParticleType::BlockBreak.create_particle(&mut entities, entity);
-                self.block_break_info.lock().effect_id.replace(entity);
-                return true;
+            if !game.focused {
+                let mut mouse_buttons = entities
+                    .world
+                    .entity_mut(player.1)
+                    .get_mut::<MouseButtons>()
+                    .unwrap();
+                mouse_buttons.left = false;
+                mouse_buttons.right = false;
+                return;
             }
-            return false;
         }
-        self.abort_breaking(false);
-        true
     }
 
     pub fn key_press(&self, down: bool, key: Actionkey, focused: &mut bool) -> bool {
@@ -1421,91 +1302,23 @@ impl Server {
 
     #[allow(unused_must_use)]
     pub fn on_left_click(&self) {
-        packet::send_arm_swing(
-            self.conn.clone().write().as_mut().unwrap(),
-            self.mapped_protocol_version,
-            Hand::MainHand,
-        )
-        .map_err(|_| self.disconnect_closed(None));
-        // TODO: Implement clientside animation.
-        if self.player.clone().read().is_some() {
-            let world = self.world.clone();
-            let gamemode = *self
-                .entities
-                .read()
-                .world
-                .entity(self.player.clone().read().as_ref().unwrap().1)
-                .get::<GameMode>()
-                .unwrap();
-            if gamemode.can_interact_with_world() && self.block_break_info.lock().delay == 0 {
-                self.block_break_info.lock().pressed = true;
-                // TODO: Check this
-                if let Some((pos, _, face, _)) = target::trace_ray(
-                    &world,
-                    4.0,
-                    self.renderer.camera.lock().pos.to_vec(),
-                    self.renderer.view_vector.lock().cast().unwrap(),
-                    target::test_block,
-                ) {
-                    packet::send_digging(
-                        self.conn.clone().write().as_mut().unwrap(),
-                        self.mapped_protocol_version,
-                        DigType::StartDestroyBlock,
-                        pos,
-                        face.index() as u8,
-                    )
-                    .map_err(|_| self.disconnect_closed(None));
-                    self.block_break_info.lock().break_face = face;
-                    self.block_break_info.lock().break_position = pos;
-                    self.block_break_info.lock().progress = 0.0;
-                    self.block_break_info.lock().hardness = 1.0; // TODO: Get actual hardness values depending on blocktype and version and tool in hands
-                    self.block_break_info.lock().active = true;
-                    if let Some(break_id) = self.block_break_info.lock().effect_id.take() {
-                        self.entities.clone().write().world.despawn(break_id);
-                    }
-
-                    let entities = self.entities.clone();
-                    let mut entities = entities.write();
-                    let mut entity = entities.world.spawn();
-                    entity.insert(BlockEffectData {
-                        position: Vector3::new(pos.x as f64, pos.y as f64, pos.z as f64),
-                        status: -1,
-                    });
-                    let entity = entity.id();
-                    ParticleType::BlockBreak.create_particle(&mut entities, entity);
-                    self.block_break_info.lock().effect_id.replace(entity);
-                }
-            }
-        }
+        let mut entities = self.entities.write();
+        let mut mouse_buttons = entities
+            .world
+            .entity_mut(self.player.read().unwrap().1)
+            .get_mut::<MouseButtons>()
+            .unwrap();
+        mouse_buttons.left = true;
     }
 
     pub fn on_release_left_click(&self) {
-        self.abort_breaking(true);
-    }
-
-    #[allow(unused_must_use)]
-    pub fn abort_breaking(&self, unpress: bool) {
-        if unpress && self.block_break_info.lock().pressed {
-            self.block_break_info.lock().pressed = false;
-        }
-        if let Some(break_id) = self.block_break_info.lock().effect_id.take() {
-            self.entities.clone().write().world.despawn(break_id);
-        }
-        // TODO: Call this on hand switching (hotbar scrolling), but let pressed as it is!
-        if self.block_break_info.lock().active {
-            self.block_break_info.lock().active = false;
-            self.block_break_info.lock().delay = 5;
-            let pos = self.block_break_info.lock().break_position;
-            let face = self.block_break_info.lock().break_face;
-            packet::send_digging(
-                self.conn.clone().write().as_mut().unwrap(),
-                self.mapped_protocol_version,
-                DigType::AbortDestroyBlock,
-                pos,
-                face.index() as u8,
-            )
-            .map_err(|_| self.disconnect_closed(None));
-        }
+        let mut entities = self.entities.write();
+        let mut mouse_buttons = entities
+            .world
+            .entity_mut(self.player.read().unwrap().1)
+            .get_mut::<MouseButtons>()
+            .unwrap();
+        mouse_buttons.left = false;
     }
 
     #[allow(unused_must_use)]

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -72,7 +72,7 @@ pub struct World {
 
     block_entity_actions: (Sender<BlockEntityAction>, Receiver<BlockEntityAction>),
 
-    protocol_version: i32,
+    pub protocol_version: i32,
     pub modded_block_ids: Arc<RwLock<HashMap<usize, String>>>,
     pub id_map: Arc<block::VanillaIDMap>,
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -72,7 +72,7 @@ pub struct World {
 
     block_entity_actions: (Sender<BlockEntityAction>, Receiver<BlockEntityAction>),
 
-    pub protocol_version: i32,
+    protocol_version: i32,
     pub modded_block_ids: Arc<RwLock<HashMap<usize, String>>>,
     pub id_map: Arc<block::VanillaIDMap>,
 }


### PR DESCRIPTION
I've added basic support for breaking blocks. At the moment, it can calculate the time required to mine each block for each tool with these exceptions:
- Using swords: Cobwebs, cocoa, leaves, melons, pumpkins, vines
- Using shears: Cobwebs, wool, leaves, vines

As part of this, I moved some of the existing code from `Server` into an ECS system to make it easier to maintain.