### PR TITLE
Make the void non-solid

### DIFF
--- a/src/world/chunk/chunk_section.rs
+++ b/src/world/chunk/chunk_section.rs
@@ -186,7 +186,7 @@ impl ChunkSectionSnapshotGroup {
         let x = if x < 0 { 16 + x } else { x & 15 };
         let y = if y < 0 { 16 + y } else { y & 15 };
         let z = if z < 0 { 16 + z } else { z & 15 };
-        section.map_or(block::Missing {}, |s| s.get_block(x, y, z))
+        section.map_or(block::Air {}, |s| s.get_block(x, y, z))
     }
 
     pub fn get_block_light(&self, x: i32, y: i32, z: i32) -> u8 {

--- a/src/world/chunk/mod.rs
+++ b/src/world/chunk/mod.rs
@@ -107,7 +107,7 @@ impl Chunk {
     pub(crate) fn get_block(&self, x: i32, y: i32, z: i32) -> block::Block {
         let s_idx = y >> 4;
         if !(0..=15).contains(&s_idx) {
-            return block::Missing {};
+            return block::Air {};
         }
         match self.sections[s_idx as usize].as_ref() {
             Some(sec) => sec.get_block(x, y & 0xF, z),


### PR DESCRIPTION
This fixes #113. There is a rendering issue when the player is outside the valid y values which prevents the world blocks from being displayed. I couldn't figure out the cause, but it might not matter if we are planning on changing the renderer (#212).