### PR TITLE
Optimise chunk loading

### DIFF
--- a/src/chunk_builder.rs
+++ b/src/chunk_builder.rs
@@ -62,11 +62,9 @@ impl ChunkBuilder {
         while let Ok((id, mut val)) = self.built_recv.try_recv() {
             world.clone().reset_building_flag(val.position);
 
-            let world = world.clone();
-            let chunks = world.chunks.clone();
+            let mut chunks = world.chunks.write();
             let chunk = chunks.get_mut(&CPos(val.position.0, val.position.2));
-            if chunk.as_ref().is_some() {
-                let mut chunk = chunk.unwrap();
+            if let Some(chunk) = chunk {
                 let section = chunk.sections[val.position.1 as usize].as_mut();
 
                 if let Some(sec) = section {

--- a/src/world/chunk/chunk_section.rs
+++ b/src/world/chunk/chunk_section.rs
@@ -8,6 +8,7 @@ use parking_lot::RwLock;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct ChunkSection {
     pub cull_info: chunk_builder::CullInfo,
     pub render_buffer: Arc<RwLock<render::ChunkBuffer>>,
@@ -147,8 +148,8 @@ impl ChunkSectionSnapshotGroup {
         ];
         for xo in -1..2 {
             for zo in -1..2 {
-                let chunk = chunk_lookup.get(&CPos(x + xo, z + zo));
-                let chunk = chunk.as_ref();
+                let chunks = chunk_lookup.read();
+                let chunk = chunks.get(&CPos(x + xo, z + zo));
                 for yo in -1..2 {
                     let section = if let Some(chunk) = chunk {
                         if y + yo != (y + yo) & 15 {

--- a/src/world/chunk/mod.rs
+++ b/src/world/chunk/mod.rs
@@ -13,9 +13,10 @@ use bevy_ecs::prelude::Entity;
 
 mod chunk_section;
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
 pub struct CPos(pub i32, pub i32);
 
+#[derive(Clone)]
 pub struct Chunk {
     pub(crate) position: CPos,
 

--- a/src/world/storage.rs
+++ b/src/world/storage.rs
@@ -1,80 +1,31 @@
-use crate::types::bit;
-use crate::types::hash::FNVHash;
 use crate::world::block;
-
-use std::collections::HashMap;
-use std::hash::BuildHasherDefault;
 
 #[derive(Clone)]
 pub struct BlockStorage {
-    blocks: bit::Map,
-    block_map: Vec<(block::Block, u32)>,
-    rev_block_map: HashMap<block::Block, usize, BuildHasherDefault<FNVHash>>,
+    blocks: Vec<block::Block>,
 }
 
 impl BlockStorage {
-    pub fn new(size: usize) -> BlockStorage {
+    pub fn new(size: usize) -> Self {
         Self::new_default(size, block::Air {})
     }
 
-    pub fn new_default(size: usize, def: block::Block) -> BlockStorage {
-        let mut storage = BlockStorage {
-            blocks: bit::Map::new(size, 4),
-            block_map: vec![(def, size as u32)],
-            rev_block_map: HashMap::with_hasher(BuildHasherDefault::default()),
-        };
-        storage.rev_block_map.insert(def, 0);
-        storage
+    pub fn new_default(size: usize, def: block::Block) -> Self {
+        Self {
+            blocks: vec![def; size],
+        }
     }
 
     pub fn get(&self, idx: usize) -> block::Block {
-        let idx = self.blocks.get(idx);
-        self.block_map[idx].0
+        self.blocks[idx]
     }
 
     pub fn set(&mut self, idx: usize, b: block::Block) -> bool {
-        use std::collections::hash_map::Entry;
-        let old = self.get(idx);
-        if old == b {
-            return false;
+        if self.blocks[idx] == b {
+            false
+        } else {
+            self.blocks[idx] = b;
+            true
         }
-        // Clean up the old block
-        {
-            let idx = *self.rev_block_map.get(&old).unwrap();
-            let info = &mut self.block_map[idx];
-            info.1 -= 1;
-            if info.1 == 0 {
-                // None left of this type
-                self.rev_block_map.remove(&old);
-            }
-        }
-
-        if let Entry::Vacant(entry) = self.rev_block_map.entry(b) {
-            let mut found = false;
-            let id = entry.insert(self.block_map.len());
-            for (i, ref mut info) in self.block_map.iter_mut().enumerate() {
-                if info.1 == 0 {
-                    info.0 = b;
-                    *id = i;
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                if self.block_map.len() >= 1 << self.blocks.bit_size {
-                    let new_size = self.blocks.bit_size + 1;
-                    self.blocks = self.blocks.resize(new_size);
-                }
-                self.block_map.push((b, 0));
-            }
-        }
-
-        {
-            let b_idx = self.rev_block_map[&b];
-            let info = &mut self.block_map[b_idx];
-            info.1 += 1;
-            self.blocks.set(idx, b_idx);
-        }
-        true
     }
 }


### PR DESCRIPTION
I started doing some benchmarking on the code that loads chunk since I noticed the game becomes a bit jumpy when entering a new area. After doing a bit of testing with a few different methods of optimisation, it seems like the main causes were:
- The chunk `DashMap` hash function
- The locking while loading a chunk
- The `BlockStorage` structure

The first thing I noticed was that a large amount of the time was used up by `DashMap` hash function. I tried to switch to a faster one, but nothing really seemed to beat the custom FNV hash that we have already. Since the chunk hashmap is indexed with two i32s, I tried to use a `BTreeMap` instead since the comparison should be faster than using a hash function for such a simple key. It ended up dropping from ~6.2ms to ~4.1ms per chunk.

One of the downsides of using `BTreeMap` rather than `DashMap` was that chunks couldn't be loaded concurrently since it keeps a write lock for the entire `load_chunk()` call. Using `DashMap` allows for locking multiple chunks if accessing values in different shards inside the `DashMap`. To resolve this issue while still using a `BTreeMap`, I changed `load_chunk()` to make a copy of the chunk at the start, update the chunk, and then write the copy back at the end. I was expecting this to add a little more time to the process, but I couldn't see any difference on the benchmark results. This also allows any number of chunks to be loaded concurrently, only blocking other threads while attempting to replace the chunk at the end.

The next thing I found was the `BlockStorage` struct. It seemed to be using a structure similar to the palette structure the chunk is sent in. When I switched this to use a `Vec<Block>`, it dropped from ~4.1ms to ~2.9ms per chunk. I tested the effect this had on memory by running the client with both implementations, and it seems like it only used ~20mb of extra memory.

After making these changes, the game was noticeably less jumpy when going into new regions. I think the majority of this was changing the locking structure, since anything that needed to read the world state was less likely to conflict with the `load_chunk()` write lock. The other optimisations are less important but still make chunks load faster in new regions.