### PR TITLE
render furnace smelting and some improvements

### DIFF
--- a/src/inventory/anvil_inventory.rs
+++ b/src/inventory/anvil_inventory.rs
@@ -115,7 +115,7 @@ impl Inventory for AnvilInventory {
             renderer.screen_data.read().center().1 as f64 - icon_scale * WINDOW_HEIGHT as f64 / 2.0;
         basic_elements.push(
             ui::ImageBuilder::new()
-                .texture_coords((0.0 / 256.0, 0.0 / 256.0, 176.0 / 256.0, 166.0 / 256.0))
+                .texture_coords((0.0, 0.0, 176.0, 166.0))
                 .position(top_left_x, top_left_y)
                 .alignment(ui::VAttach::Top, ui::HAttach::Left)
                 .size(icon_scale * 176.0, icon_scale * 166.0)
@@ -128,7 +128,7 @@ impl Inventory for AnvilInventory {
             ui::ImageBuilder::new()
                 .draw_index(5)
                 .texture("minecraft:gui/container/anvil")
-                .texture_coords((0.0 / 256.0, 182.0 / 256.0, 110.0 / 256.0, 16.0 / 256.0))
+                .texture_coords((0.0, 182.0, 110.0, 16.0))
                 .position(
                     top_left_x + 59.0 * icon_scale,
                     top_left_y + 20.0 * icon_scale,
@@ -142,7 +142,7 @@ impl Inventory for AnvilInventory {
         basic_elements.push(
             ui::ImageBuilder::new()
                 .texture("minecraft:gui/container/anvil")
-                .texture_coords((176.0 / 256.0, 0.0 / 256.0, 28.0 / 256.0, 21.0 / 256.0))
+                .texture_coords((176.0, 0.0, 28.0, 21.0))
                 .position(
                     top_left_x + 98.0 * icon_scale,
                     top_left_y + 44.0 * icon_scale,

--- a/src/inventory/chest_inventory.rs
+++ b/src/inventory/chest_inventory.rs
@@ -109,10 +109,10 @@ impl Inventory for ChestInventory {
         basic_elements.push(
             ui::ImageBuilder::new()
                 .texture_coords((
-                    0.0 / 256.0,
-                    0.0 / 256.0,
-                    WINDOW_WIDTH as f64 / 256.0,
-                    chest_height(self.rows) as f64 / 256.0,
+                    0.0,
+                    0.0,
+                    WINDOW_WIDTH as f64,
+                    chest_height(self.rows) as f64,
                 ))
                 .position(
                     (center.0 as i32 - total_width_scaled / 2) as f64,
@@ -128,10 +128,10 @@ impl Inventory for ChestInventory {
         basic_elements.push(
             ui::ImageBuilder::new()
                 .texture_coords((
-                    0.0 / 256.0,
-                    (chest_height(6) + 1) as f64 / 256.0,
-                    WINDOW_WIDTH as f64 / 256.0,
-                    INVENTORY_HEIGHT as f64 / 256.0,
+                    0.0,
+                    (chest_height(6) + 1) as f64,
+                    WINDOW_WIDTH as f64,
+                    INVENTORY_HEIGHT as f64,
                 ))
                 .position(
                     (center.0 as i32 - total_width_scaled / 2) as f64,

--- a/src/inventory/crafting_table_inventory.rs
+++ b/src/inventory/crafting_table_inventory.rs
@@ -95,7 +95,7 @@ impl Inventory for CraftingTableInventory {
         // Crafting table texture
         basic_elements.push(
             ui::ImageBuilder::new()
-                .texture_coords((0.0 / 256.0, 0.0 / 256.0, 176.0 / 256.0, 166.0 / 256.0))
+                .texture_coords((0.0, 0.0, 176.0, 166.0))
                 .position(
                     center.0 as f64 - icon_scale * WINDOW_WIDTH as f64 / 2.0,
                     center.1 as f64 - icon_scale * WINDOW_HEIGHT as f64 / 2.0,

--- a/src/inventory/dropper_inventory.rs
+++ b/src/inventory/dropper_inventory.rs
@@ -97,12 +97,7 @@ impl Inventory for DropperInventory {
         // Dropper texture
         basic_elements.push(
             ui::ImageBuilder::new()
-                .texture_coords((
-                    0.0 / 256.0,
-                    0.0 / 256.0,
-                    WINDOW_WIDTH as f64 / 256.0,
-                    WINDOW_HEIGHT as f64 / 256.0,
-                ))
+                .texture_coords((0.0, 0.0, WINDOW_WIDTH as f64, WINDOW_HEIGHT as f64))
                 .position(
                     center.0 as f64 - icon_scale * WINDOW_WIDTH as f64 / 2.0,
                     center.1 as f64 - icon_scale * WINDOW_HEIGHT as f64 / 2.0,

--- a/src/inventory/enchanting_table_inventory.rs
+++ b/src/inventory/enchanting_table_inventory.rs
@@ -20,12 +20,9 @@ const WINDOW_WIDTH: i32 = 176;
 const WINDOW_HEIGHT: i32 = 166;
 
 //textur coords for the buttons
-const BUTTON_ACTIVE: (f64, f64, f64, f64) =
-    (0.0 / 256.0, 166.0 / 256.0, 108.0 / 256.0, 19.0 / 256.0);
-const BUTTON_INACTIVE: (f64, f64, f64, f64) =
-    (0.0 / 256.0, 185.0 / 256.0, 108.0 / 256.0, 19.0 / 256.0);
-const BUTTON_FOCUSED: (f64, f64, f64, f64) =
-    (0.0 / 256.0, 204.0 / 256.0, 108.0 / 256.0, 19.0 / 256.0);
+const BUTTON_ACTIVE: (f64, f64, f64, f64) = (0.0, 166.0, 108.0, 19.0);
+const BUTTON_INACTIVE: (f64, f64, f64, f64) = (0.0, 185.0, 108.0, 19.0);
+const BUTTON_FOCUSED: (f64, f64, f64, f64) = (0.0, 204.0, 108.0, 19.0);
 
 pub struct EnchantmentTableInventory {
     slots: SlotMapping,
@@ -182,7 +179,7 @@ impl Inventory for EnchantmentTableInventory {
         // enchantment table texture
         basic_elements.push(
             ui::ImageBuilder::new()
-                .texture_coords((0.0 / 256.0, 0.0 / 256.0, 176.0 / 256.0, 166.0 / 256.0))
+                .texture_coords((0.0, 0.0, 176.0, 166.0))
                 .position(top_left_x, top_left_y)
                 .alignment(ui::VAttach::Top, ui::HAttach::Left)
                 .size(icon_scale * 176.0, icon_scale * 166.0)
@@ -263,12 +260,7 @@ impl Inventory for EnchantmentTableInventory {
             basic_elements.push(
                 level_requ
                     .clone()
-                    .texture_coords((
-                        (2.0 + 16.0 * i as f64) / 256.0,
-                        225.0 / 256.0,
-                        13.0 / 256.0,
-                        11.0 / 256.0,
-                    ))
+                    .texture_coords(((2.0 + 16.0 * i as f64), 225.0, 13.0, 11.0))
                     .position(
                         top_left_x + 62.0 * icon_scale,
                         top_left_y + 17.0 * icon_scale + 19.0 * i as f64 * icon_scale,
@@ -374,12 +366,7 @@ impl Inventory for EnchantmentTableInventory {
                         .get_mut(len_el - (3 - i))
                         .unwrap()
                         .borrow_mut()
-                        .texture_coords = (
-                        (2.0 + 16.0 * i as f64) / 256.0,
-                        225.0 / 256.0,
-                        13.0 / 256.0,
-                        11.0 / 256.0,
-                    );
+                        .texture_coords = ((2.0 + 16.0 * i as f64), 225.0, 13.0, 11.0);
 
                     // name of the enchantment and level
                     basic_text_elements
@@ -426,12 +413,7 @@ impl Inventory for EnchantmentTableInventory {
                         .get_mut(len_el - (3 - i))
                         .unwrap()
                         .borrow_mut()
-                        .texture_coords = (
-                        (2.0 + 16.0 * i as f64) / 256.0,
-                        241.0 / 256.0,
-                        13.0 / 256.0,
-                        11.0 / 256.0,
-                    );
+                        .texture_coords = ((2.0 + 16.0 * i as f64), 241.0, 13.0, 11.0);
 
                     // the buttons
                     basic_elements

--- a/src/inventory/player_inventory.rs
+++ b/src/inventory/player_inventory.rs
@@ -111,12 +111,7 @@ impl Inventory for PlayerInventory {
         // Inventory window
         basic_elements.push(
             ui::ImageBuilder::new()
-                .texture_coords((
-                    0.0 / 256.0,
-                    0.0 / 256.0,
-                    WINDOW_WIDTH as f64 / 256.0,
-                    WINDOW_HEIGHT as f64 / 256.0,
-                ))
+                .texture_coords((0.0, 0.0, WINDOW_WIDTH as f64, WINDOW_HEIGHT as f64))
                 .position(
                     center.0 as f64 - icon_scale * WINDOW_WIDTH as f64 / 2.0,
                     center.1 as f64 - icon_scale * WINDOW_HEIGHT as f64 / 2.0,
@@ -135,12 +130,7 @@ impl Inventory for PlayerInventory {
         if self.version < Version::V1_9 {
             basic_elements.push(
                 ui::ImageBuilder::new()
-                    .texture_coords((
-                        (WINDOW_WIDTH as f64 / 2.0 - 9.0) / 256.0,
-                        10.0 / 256.0,
-                        18.0 / 256.0,
-                        18.0 / 256.0,
-                    ))
+                    .texture_coords(((WINDOW_WIDTH as f64 / 2.0 - 9.0), 10.0, 18.0, 18.0))
                     .position(
                         center.0 as f64 - icon_scale * (WINDOW_WIDTH as f64 / 2.0 - 76.0),
                         center.1 as f64 - icon_scale * (WINDOW_HEIGHT as f64 / 2.0 - 61.0),

--- a/src/render/hud.rs
+++ b/src/render/hud.rs
@@ -547,11 +547,11 @@ impl Hud {
         let updated_offset = if updated_health { 9.0 } else { 0.0 };
         let hardcore_offset = if hud_context.hardcore { 5.0 } else { 0.0 };
         let texture_offset = if hud_context.poison {
-            16 + 36
+            16.0 + 36.0
         } else if hud_context.wither {
-            16 + 72
+            16.0 + 72.0
         } else {
-            16
+            16.0
         };
         drop(hud_context);
         let mut redirty_health = false;
@@ -574,12 +574,7 @@ impl Hud {
 
             let image = ui::ImageBuilder::new()
                 .draw_index(HUD_PRIORITY)
-                .texture_coords((
-                    (16.0 + updated_offset) as f64 / 256.0,
-                    (9.0 * hardcore_offset) as f64 / 256.0,
-                    9.0 / 256.0,
-                    9.0 / 256.0,
-                ))
+                .texture_coords((16.0 + updated_offset, 9.0 * hardcore_offset, 9.0, 9.0))
                 .position(x, y)
                 .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                 .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -591,12 +586,7 @@ impl Hud {
                 if heart as f32 * 2.0 + 1.0 < last_health {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (texture_offset + 54) as f64 / 256.0,
-                            (9.0 * hardcore_offset) as f64 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords((texture_offset + 54.0, 9.0 * hardcore_offset, 9.0, 9.0))
                         .position(x, y)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -606,12 +596,7 @@ impl Hud {
                 } else if heart as f32 * 2.0 + 1.0 == last_health {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (texture_offset + 63) as f64 / 256.0,
-                            (9.0 * hardcore_offset) as f64 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords((texture_offset + 63.0, 9.0 * hardcore_offset, 9.0, 9.0))
                         .position(x, y)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -625,12 +610,7 @@ impl Hud {
                 if tmp_absorbtion == absorbtion && absorbtion % 2.0 == 1.0 {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (texture_offset + 153) as f64 / 256.0,
-                            (9.0 * hardcore_offset) as f64 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords((texture_offset + 153.0, 9.0 * hardcore_offset, 9.0, 9.0))
                         .position(x, y)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -640,12 +620,7 @@ impl Hud {
                 } else {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (texture_offset + 144) as f64 / 256.0,
-                            (9.0 * hardcore_offset) as f64 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords((texture_offset + 144.0, 9.0 * hardcore_offset, 9.0, 9.0))
                         .position(x, y)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -659,12 +634,7 @@ impl Hud {
                 if heart * 2 + 1 < hp as isize {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (texture_offset + 36) as f64 / 256.0,
-                            (9.0 * hardcore_offset) as f64 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords((texture_offset + 36.0, 9.0 * hardcore_offset, 9.0, 9.0))
                         .position(x, y)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -676,12 +646,7 @@ impl Hud {
                 if heart * 2 + 1 == hp as isize {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (texture_offset + 45) as f64 / 256.0,
-                            (9.0 * hardcore_offset) as f64 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords((texture_offset + 45.0, 9.0 * hardcore_offset, 9.0, 9.0))
                         .position(x, y)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -716,12 +681,7 @@ impl Hud {
                 };
                 let image = ui::ImageBuilder::new()
                     .draw_index(HUD_PRIORITY)
-                    .texture_coords((
-                        texture_offset / 256.0,
-                        9.0 / 256.0,
-                        9.0 / 256.0,
-                        9.0 / 256.0,
-                    ))
+                    .texture_coords((texture_offset, 9.0, 9.0, 9.0))
                     .position(x, y)
                     .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                     .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -756,12 +716,7 @@ impl Hud {
             let x = x_offset - i as f64 * (icon_scale * 8.0) - icon_scale * 9.0;
             let image = ui::ImageBuilder::new()
                 .draw_index(HUD_PRIORITY)
-                .texture_coords((
-                    (16.0 + j8 * 9.0) / 256.0,
-                    27.0 / 256.0,
-                    9.0 / 256.0,
-                    9.0 / 256.0,
-                ))
+                .texture_coords(((16.0 + j8 * 9.0), 27.0, 9.0, 9.0))
                 .position(x, y_offset)
                 .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                 .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -773,12 +728,7 @@ impl Hud {
                 Ordering::Less => {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (l7 + 36.0) / 256.0,
-                            27.0 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords(((l7 + 36.0), 27.0, 9.0, 9.0))
                         .position(x, y_offset)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -789,12 +739,7 @@ impl Hud {
                 Ordering::Equal => {
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((
-                            (l7 + 45.0) / 256.0,
-                            27.0 / 256.0,
-                            9.0 / 256.0,
-                            9.0 / 256.0,
-                        ))
+                        .texture_coords(((l7 + 45.0), 27.0, 9.0, 9.0))
                         .position(x, y_offset)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -823,7 +768,7 @@ impl Hud {
         if max_exp > 0 {
             let image = ui::ImageBuilder::new()
                 .draw_index(HUD_PRIORITY)
-                .texture_coords((0.0 / 256.0, 64.0 / 256.0, 182.0 / 256.0, 5.0 / 256.0))
+                .texture_coords((0.0, 64.0, 182.0, 5.0))
                 .position(0.0, y_offset)
                 .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                 .size(icon_scale * 182.0, icon_scale * 5.0)
@@ -836,12 +781,7 @@ impl Hud {
                 let shift = icon_scale * (((182.0) - scaled_length as f64) / 2.0);
                 let image = ui::ImageBuilder::new()
                     .draw_index(HUD_PRIORITY)
-                    .texture_coords((
-                        0.0 / 256.0,
-                        69.0 / 256.0,
-                        scaled_length as f64 / 256.0,
-                        5.0 / 256.0,
-                    ))
+                    .texture_coords((0.0, 69.0, scaled_length as f64, 5.0))
                     .position(shift * -1.0, y_offset)
                     .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                     .size(icon_scale * scaled_length as f64, icon_scale * 5.0)
@@ -923,7 +863,7 @@ impl Hud {
         let icon_scale = Hud::icon_scale(renderer);
         let image = ui::ImageBuilder::new()
             .draw_index(HUD_PRIORITY)
-            .texture_coords((0.0 / 256.0, 0.0 / 256.0, 182.0 / 256.0, 22.0 / 256.0))
+            .texture_coords((0.0, 0.0, 182.0, 22.0))
             .position(0.0, 0.0)
             .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
             .size(icon_scale * 182.0, icon_scale * 22.0)
@@ -971,7 +911,7 @@ impl Hud {
         let slot = self.hud_context.clone().read().slot_index as f64;
         let image = ui::ImageBuilder::new()
             .draw_index(HUD_PRIORITY)
-            .texture_coords((0.0 / 256.0, 22.0 / 256.0, 24.0 / 256.0, 22.0 / 256.0))
+            .texture_coords((0.0, 22.0, 24.0, 22.0))
             .position(
                 (icon_scale) * -1.0
                     + -(icon_scale * 90.0)
@@ -995,7 +935,7 @@ impl Hud {
         let icon_scale = Hud::icon_scale(renderer);
         let image = ui::ImageBuilder::new()
             .draw_index(HUD_PRIORITY)
-            .texture_coords((0.0 / 256.0, 0.0 / 256.0, 16.0 / 256.0, 16.0 / 256.0))
+            .texture_coords((0.0, 0.0, 16.0, 16.0))
             .position(0.0, 0.0)
             .alignment(ui::VAttach::Middle, ui::HAttach::Center)
             .size(icon_scale * 16.0, icon_scale * 16.0)
@@ -1025,7 +965,7 @@ impl Hud {
                     // normal bubble
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((16.0 / 256.0, 18.0 / 256.0, 9.0 / 256.0, 9.0 / 256.0))
+                        .texture_coords((16.0, 18.0, 9.0, 9.0))
                         .position(x, y_offset)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -1036,7 +976,7 @@ impl Hud {
                     // broken bubble
                     let image = ui::ImageBuilder::new()
                         .draw_index(HUD_PRIORITY)
-                        .texture_coords((25.0 / 256.0, 18.0 / 256.0, 9.0 / 256.0, 9.0 / 256.0))
+                        .texture_coords((25.0, 18.0, 9.0, 9.0))
                         .position(x, y_offset)
                         .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
                         .size(icon_scale * 9.0, icon_scale * 9.0)
@@ -1163,7 +1103,7 @@ impl Hud {
             };
         ui::ImageBuilder::new()
             .draw_index(HUD_PRIORITY)
-            .texture_coords((0.0, 0.0, 1.0, 1.0))
+            .texture_coords((0.0, 0.0, 256.0, 256.0))
             .position(x, y)
             .alignment(ui::VAttach::Bottom, ui::HAttach::Center)
             .size(icon_scale * 16.0, icon_scale * 16.0)

--- a/src/render/inventory.rs
+++ b/src/render/inventory.rs
@@ -150,7 +150,7 @@ impl InventoryWindow {
                 textures.1
             };
         let image = ui::ImageBuilder::new()
-            .texture_coords((0.0, 0.0, 1.0, 1.0))
+            .texture_coords((0.0, 0.0, 256.0, 256.0))
             .position(x, y)
             .alignment(v_attach, ui::HAttach::Left)
             .size(icon_scale * 16.0, icon_scale * 16.0)

--- a/src/screen/server_list.rs
+++ b/src/screen/server_list.rs
@@ -202,7 +202,7 @@ impl ServerList {
                 .texture("gui/icons")
                 .position(5.0, 5.0)
                 .size(20.0, 16.0)
-                .texture_coords((0.0, 56.0 / 256.0, 10.0 / 256.0, 8.0 / 256.0))
+                .texture_coords((0.0, 56.0, 10.0, 8.0))
                 .alignment(ui::VAttach::Top, ui::HAttach::Right)
                 .attach(&mut *back.borrow_mut());
 
@@ -587,12 +587,12 @@ impl super::Screen for ServerList {
                         let ping_ms = (res.ping.subsec_nanos() as f64) / 1000000.0
                             + (res.ping.as_secs() as f64) * 1000.0;
                         let y = match ping_ms.round() as u64 {
-                            _x @ 0..=75 => 16.0 / 256.0,
-                            _x @ 76..=150 => 24.0 / 256.0,
-                            _x @ 151..=225 => 32.0 / 256.0,
-                            _x @ 226..=350 => 40.0 / 256.0,
-                            _x @ 351..=999 => 48.0 / 256.0,
-                            _ => 56.0 / 256.0,
+                            _x @ 0..=75 => 16.0,
+                            _x @ 76..=150 => 24.0,
+                            _x @ 151..=225 => 32.0,
+                            _x @ 226..=350 => 40.0,
+                            _x @ 351..=999 => 48.0,
+                            _ => 56.0,
                         };
                         s.ping.borrow_mut().texture_coords.1 = y;
                         if res.exists {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -710,18 +710,15 @@ impl Server {
                         }
                         MappedPacket::WindowProperty(data) => {
                             let win_id: i32 = data.id as i32;
-                            let inv = server
-                                .inventory_context
-                                .read()
-                                .safe_inventory
-                                .clone()
-                                .unwrap();
-
-                            if inv.read().id() == win_id {
-                                inv.write()
-                                    .handle_property_packet(data.property, data.value);
-                            } else {
-                                warn!("The server has send information about a inventory that is not open. Did it try to crash you?");
+                            if let Some(inv) =
+                                server.inventory_context.read().safe_inventory.clone()
+                            {
+                                if inv.read().id() == win_id {
+                                    inv.write()
+                                        .handle_property_packet(data.property, data.value);
+                                } else {
+                                    warn!("The server has send information about a inventory that is not open. Did it try to crash you?");
+                                }
                             }
                         }
                         MappedPacket::WindowSetSlot(set_slot) => {

--- a/src/ui/logo.rs
+++ b/src/ui/logo.rs
@@ -73,10 +73,10 @@ impl Logo {
                     .position(x as f64, y as f64)
                     .size(4.0, 8.0)
                     .texture_coords((
-                        (x % 16) as f64 / 16.0,
-                        (y % 16) as f64 / 16.0,
-                        4.0 / 16.0,
-                        8.0 / 16.0,
+                        (x % 16) as f64 / 16.0 * 256.0,
+                        (y % 16) as f64 / 16.0 * 256.0,
+                        4.0 / 16.0 * 256.0,
+                        8.0 / 16.0 * 256.0,
                     ))
                     .colour((r, g, b, 255))
                     .attach(&mut *layer0.borrow_mut());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -841,7 +841,7 @@ element! {
         hardcode last_texture_coords = (0.0, 0.0, 0.0, 0.0),
         simple texture: String,
         optional colour: (u8, u8, u8, u8) = (255, 255, 255, 255),
-        optional texture_coords: (f64, f64, f64, f64) = (0.0, 0.0, 1.0, 1.0),
+        optional texture_coords: (f64, f64, f64, f64) = (0.0, 0.0, 256.0, 256.0),
         noset width: f64 = |b| b.width.expect("Missing required field width"),
         noset height: f64 = |b| b.height.expect("Missing required field height"),
     }
@@ -875,10 +875,10 @@ impl UIElement for Image {
                 r.y,
                 r.w,
                 r.h,
-                self.texture_coords.0,
-                self.texture_coords.1,
-                self.texture_coords.2,
-                self.texture_coords.3,
+                self.texture_coords.0 / 256.0,
+                self.texture_coords.1 / 256.0,
+                self.texture_coords.2 / 256.0,
+                self.texture_coords.3 / 256.0,
             );
             element.r = self.colour.0;
             element.g = self.colour.1;


### PR DESCRIPTION
This makes the furnace (and smoker and blast furnace) render the fire and the arrow symbol to show the smelting progress.
It also fixes a bug i created in my last PR in server/mod.rs. Where we would get a crash if the server send a WindowProperty packet after the Inventory had already been closed. These packets are now ignored if the associated inventory is not open.

The texture_coords of all ui elements are expected to be divided by 256 by the renderer, which led to some boilerplate whenever the texture_coords were set or modified, so i made the function do the division internally to remove a lot of "/ 256.0"
Along the way i also simplified some of the int to float Conversion in renderer/hud.rs by making the texture_offset variable a float.