### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,17 +27,16 @@ jobs:
             release-name: Leafish.app
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         id: toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: clippy, rustfmt
-          default: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -81,7 +80,7 @@ jobs:
           zip -r Leafish.app.zip Leafish.app
 
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.release-name }}
           path: target/release/${{ matrix.target-name }}


### PR DESCRIPTION
The following updates are performed:

* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* update [`actions/cache`](https://github.com/actions/cache) to v3
* update [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to v3
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)


Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/Lea-fish/Leafish/actions/runs/4623145593:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1, actions/cache@v2, actions-rs/clippy-check@v1.0.7, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of some of those warnings.