### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 resolver = "2"
 description = "Multi-protocol multi-platform Minecraft-compatible client"
 repository = "https://github.com/Lea-fish/Leafish"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.bundle]
 name = "Leafish"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields