### PR TITLE
Implement hotbar slot switching + fix closing keybind

### DIFF
--- a/src/render/hud.rs
+++ b/src/render/hud.rs
@@ -458,21 +458,19 @@ impl Screen for Hud {
             .as_ref()
             .unwrap()
             .clone()
-            .write_packet(HeldItemChange {
-                slot: new_slot as i16,
-            });
+            .inventory_context
+            .write()
+            .hotbar_index = new_slot;
+        self.hud_context.write().slot_index = new_slot;
+        self.hud_context.write().dirty_slot_index = true;
         self.hud_context
             .read()
             .server
             .as_ref()
             .unwrap()
-            .clone()
-            .inventory_context
-            .clone()
-            .write()
-            .hotbar_index = new_slot;
-        self.hud_context.clone().write().slot_index = new_slot;
-        self.hud_context.clone().write().dirty_slot_index = true;
+            .write_packet(HeldItemChange {
+                slot: new_slot as i16,
+            });
     }
 
     fn on_resize(

--- a/src/render/inventory.rs
+++ b/src/render/inventory.rs
@@ -3,7 +3,7 @@ use crate::render::hud::Hud;
 use crate::render::Renderer;
 use crate::screen::{Screen, ScreenSystem};
 use crate::ui::{Container, ImageRef, TextBoxRef, TextRef, VAttach};
-use crate::{ui, Game, KeyCmp};
+use crate::{ui, Actionkey, Game};
 use parking_lot::RwLock;
 use std::sync::Arc;
 use winit::keyboard::{Key, NamedKey, PhysicalKey};
@@ -99,12 +99,16 @@ impl Screen for InventoryWindow {
     }
 
     fn on_key_press(&mut self, key: (Key, PhysicalKey), down: bool, game: &mut Game) {
-        let is_e = key.0.eq_ignore_case('e');
-        if is_e && !down && !self.initial_release {
+        let is_inv = if let PhysicalKey::Code(code) = key.1 {
+            game.keybinds.get(code, &key.0).map(|kb| kb.action) == Some(Actionkey::OpenInv)
+        } else {
+            false
+        };
+        if is_inv && !down && !self.initial_release {
             self.initial_release = true;
             return;
         }
-        if (key.0 == Key::Named(NamedKey::Escape) || is_e) && !down {
+        if (key.0 == Key::Named(NamedKey::Escape) || is_inv) && !down {
             self.inventory_context
                 .write()
                 .try_close_inventory(&game.screen_sys);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -53,6 +53,7 @@ use leafish_protocol::item::Stack;
 use leafish_protocol::protocol::login::Account;
 use leafish_protocol::protocol::mapped_packet::MappablePacket;
 use leafish_protocol::protocol::mapped_packet::MappedPacket;
+use leafish_protocol::protocol::packet::play::serverbound::HeldItemChange;
 use leafish_protocol::protocol::packet::Hand;
 use leafish_protocol::protocol::Conn;
 use log::{debug, error, info, warn};
@@ -1285,6 +1286,69 @@ impl Server {
                         self.screen_sys
                             .add_screen(Box::new(Chat::new(self.chat_ctx.clone())));
                         return true;
+                    }
+                }
+                Actionkey::Hotbar1 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 0;
+                        self.hud_context.write().update_slot_index(0);
+                        self.write_packet(HeldItemChange { slot: 0 });
+                    }
+                }
+                Actionkey::Hotbar2 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 1;
+                        self.hud_context.write().update_slot_index(1);
+                        self.write_packet(HeldItemChange { slot: 1 });
+                    }
+                }
+                Actionkey::Hotbar3 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 2;
+                        self.hud_context.write().update_slot_index(2);
+                        self.write_packet(HeldItemChange { slot: 2 });
+                    }
+                }
+                Actionkey::Hotbar4 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 3;
+                        self.hud_context.write().update_slot_index(3);
+                        self.write_packet(HeldItemChange { slot: 3 });
+                    }
+                }
+                Actionkey::Hotbar5 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 4;
+                        self.hud_context.write().update_slot_index(4);
+                        self.write_packet(HeldItemChange { slot: 4 });
+                    }
+                }
+                Actionkey::Hotbar6 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 5;
+                        self.hud_context.write().update_slot_index(5);
+                        self.write_packet(HeldItemChange { slot: 5 })
+                    }
+                }
+                Actionkey::Hotbar7 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 6;
+                        self.hud_context.write().update_slot_index(6);
+                        self.write_packet(HeldItemChange { slot: 6 });
+                    }
+                }
+                Actionkey::Hotbar8 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 7;
+                        self.hud_context.write().update_slot_index(7);
+                        self.write_packet(HeldItemChange { slot: 7 });
+                    }
+                }
+                Actionkey::Hotbar9 => {
+                    if down {
+                        self.inventory_context.write().hotbar_index = 8;
+                        self.hud_context.write().update_slot_index(8);
+                        self.write_packet(HeldItemChange { slot: 8 });
                     }
                 }
                 _ => {}

--- a/src/settings/default_keybinds.rs
+++ b/src/settings/default_keybinds.rs
@@ -92,5 +92,77 @@ pub fn create_keybinds() -> Vec<(Key, Keybind)> {
                 action: Actionkey::ToggleChat,
             },
         ),
+        (
+            Key::Character(SmolStr::new_inline("1")),
+            Keybind {
+                name: "keybind_hotbar_1",
+                description: "Keybind for selecting slot 1 of the hotbar",
+                action: Actionkey::Hotbar1,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("2")),
+            Keybind {
+                name: "keybind_hotbar_2",
+                description: "Keybind for selecting slot 2 of the hotbar",
+                action: Actionkey::Hotbar2,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("3")),
+            Keybind {
+                name: "keybind_hotbar_3",
+                description: "Keybind for selecting slot 3 of the hotbar",
+                action: Actionkey::Hotbar3,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("4")),
+            Keybind {
+                name: "keybind_hotbar_4",
+                description: "Keybind for selecting slot 4 of the hotbar",
+                action: Actionkey::Hotbar4,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("5")),
+            Keybind {
+                name: "keybind_hotbar_5",
+                description: "Keybind for selecting slot 5 of the hotbar",
+                action: Actionkey::Hotbar5,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("6")),
+            Keybind {
+                name: "keybind_hotbar_6",
+                description: "Keybind for selecting slot 6 of the hotbar",
+                action: Actionkey::Hotbar6,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("7")),
+            Keybind {
+                name: "keybind_hotbar_7",
+                description: "Keybind for selecting slot 7 of the hotbar",
+                action: Actionkey::Hotbar7,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("8")),
+            Keybind {
+                name: "keybind_hotbar_8",
+                description: "Keybind for selecting slot 8 of the hotbar",
+                action: Actionkey::Hotbar8,
+            },
+        ),
+        (
+            Key::Character(SmolStr::new_inline("9")),
+            Keybind {
+                name: "keybind_hotbar_9",
+                description: "Keybind for selecting slot 9 of the hotbar",
+                action: Actionkey::Hotbar9,
+            },
+        ),
     ]
 }

--- a/src/settings/keybinds.rs
+++ b/src/settings/keybinds.rs
@@ -181,6 +181,15 @@ pub enum Actionkey {
     ToggleHud,
     ToggleDebug,
     ToggleChat,
+    Hotbar1,
+    Hotbar2,
+    Hotbar3,
+    Hotbar4,
+    Hotbar5,
+    Hotbar6,
+    Hotbar7,
+    Hotbar8,
+    Hotbar9,
 }
 
 impl FromStr for Actionkey {
@@ -198,13 +207,22 @@ impl FromStr for Actionkey {
             "keybind_toggle_hud" => Ok(Actionkey::ToggleHud),
             "keybind_toggle_debug_info" => Ok(Actionkey::ToggleDebug),
             "keybind_toggle_chat" => Ok(Actionkey::ToggleChat),
+            "keybind_hotbar_1" => Ok(Actionkey::Hotbar1),
+            "keybind_hotbar_2" => Ok(Actionkey::Hotbar2),
+            "keybind_hotbar_3" => Ok(Actionkey::Hotbar3),
+            "keybind_hotbar_4" => Ok(Actionkey::Hotbar4),
+            "keybind_hotbar_5" => Ok(Actionkey::Hotbar5),
+            "keybind_hotbar_6" => Ok(Actionkey::Hotbar6),
+            "keybind_hotbar_7" => Ok(Actionkey::Hotbar7),
+            "keybind_hotbar_8" => Ok(Actionkey::Hotbar8),
+            "keybind_hotbar_9" => Ok(Actionkey::Hotbar9),
             _ => Err(()),
         }
     }
 }
 
 impl Actionkey {
-    const VALUES: [Actionkey; 11] = [
+    const VALUES: [Actionkey; 20] = [
         Actionkey::Forward,
         Actionkey::Backward,
         Actionkey::Left,
@@ -216,6 +234,15 @@ impl Actionkey {
         Actionkey::ToggleHud,
         Actionkey::ToggleDebug,
         Actionkey::ToggleChat,
+        Actionkey::Hotbar1,
+        Actionkey::Hotbar2,
+        Actionkey::Hotbar3,
+        Actionkey::Hotbar4,
+        Actionkey::Hotbar5,
+        Actionkey::Hotbar6,
+        Actionkey::Hotbar7,
+        Actionkey::Hotbar8,
+        Actionkey::Hotbar9,
     ];
 
     pub fn values() -> &'static [Actionkey] {


### PR DESCRIPTION
Fixes: https://github.com/Lea-fish/Leafish/issues/323
Also fixes us ignoring the keybind specified for opening the inventory when checking whether the pressed key should close the currently opened inventory.