### PR TITLE
Nametags look more like real Minecraft

### DIFF
--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -180,8 +180,6 @@ fn update_render_players(
 
         if let Some(pmodel) = &player_model.model {
             let renderer = renderer.clone();
-            let cam_yaw = renderer.camera.lock().yaw;
-            let cam_pitch = renderer.camera.lock().pitch;
             let mut models = renderer.models.lock();
             let mdl = models.get_model(pmodel).unwrap();
 
@@ -209,27 +207,16 @@ fn update_render_players(
                 disp: offset,
             });
 
-            // TODO This sucks
             if player_model.has_name_tag {
-                let view_vec = renderer.view_vector.lock();
-                let view = *view_vec;
-                let forward = Vector3::new(view.x, -view.y, view.z).normalize();;
-                let right = Vector3::unit_y().cross(forward).normalize();
-                let up = forward.cross(right).normalize();
-                
+                let view = *renderer.view_vector.lock();
+                let yaw = Rad(view.x.atan2(view.z));
+                let pitch = Rad(view.y.asin());
 
-                let rot = Matrix4::new(
-                    right.x,   right.y,   right.z,   0.0,
-                    up.x,      up.y,      up.z,      0.0,
-                    forward.x, forward.y, forward.z, 0.0,
-                    0.0,       0.0,       0.0,       1.0,
-                );
-
-                println!("up.y: {}, forward.y: {}", up.y, forward.y);
-
-                mdl.matrix[PlayerModelPart::NameTag as usize] = Matrix4::from_translation(
-                    offset + Vector3::new(0.0, (-24.0 / 16.0) - 0.6, 0.0),
-                ) * rot;
+                mdl.matrix[PlayerModelPart::NameTag as usize] = Matrix4::from(Decomposed {
+                    scale: 1.0,
+                    rot: Quaternion::from_angle_y(yaw) * Quaternion::from_angle_x(pitch),
+                    disp: offset + Vector3::new(0.0, (-24.0 / 16.0) - 0.6, 0.0),
+                });
             }
 
             mdl.matrix[PlayerModelPart::Head as usize] = offset_matrix

--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -18,7 +18,7 @@ use crate::types::GameMode;
 use crate::world;
 use arc_swap::ArcSwapOption;
 use bevy_ecs::prelude::*;
-use cgmath::{Decomposed, Matrix4, Point3, Quaternion, Rad, Rotation3, Vector3};
+use cgmath::{Decomposed, InnerSpace, Matrix4, Point3, Quaternion, Rad, Rotation3, Vector3};
 use collision::{Aabb, Aabb3};
 use instant::Instant;
 use leafish_protocol::format::Component;
@@ -180,8 +180,8 @@ fn update_render_players(
 
         if let Some(pmodel) = &player_model.model {
             let renderer = renderer.clone();
-            let cam_x = renderer.camera.lock().pos.x;
-            let cam_z = renderer.camera.lock().pos.z;
+            let cam_yaw = renderer.camera.lock().yaw;
+            let cam_pitch = renderer.camera.lock().pitch;
             let mut models = renderer.models.lock();
             let mdl = models.get_model(pmodel).unwrap();
 
@@ -211,12 +211,25 @@ fn update_render_players(
 
             // TODO This sucks
             if player_model.has_name_tag {
-                let ang = (position.position.x - cam_x).atan2(position.position.z - cam_z) as f32;
-                mdl.matrix[PlayerModelPart::NameTag as usize] = Matrix4::from(Decomposed {
-                    scale: 1.0,
-                    rot: Quaternion::from_angle_y(Rad(ang)),
-                    disp: offset + Vector3::new(0.0, (-24.0 / 16.0) - 0.6, 0.0),
-                });
+                let view_vec = renderer.view_vector.lock();
+                let view = *view_vec;
+                let forward = Vector3::new(view.x, -view.y, view.z).normalize();;
+                let right = Vector3::unit_y().cross(forward).normalize();
+                let up = forward.cross(right).normalize();
+                
+
+                let rot = Matrix4::new(
+                    right.x,   right.y,   right.z,   0.0,
+                    up.x,      up.y,      up.z,      0.0,
+                    forward.x, forward.y, forward.z, 0.0,
+                    0.0,       0.0,       0.0,       1.0,
+                );
+
+                println!("up.y: {}, forward.y: {}", up.y, forward.y);
+
+                mdl.matrix[PlayerModelPart::NameTag as usize] = Matrix4::from_translation(
+                    offset + Vector3::new(0.0, (-24.0 / 16.0) - 0.6, 0.0),
+                ) * rot;
             }
 
             mdl.matrix[PlayerModelPart::Head as usize] = offset_matrix

--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -466,17 +466,39 @@ fn add_player(renderer: Arc<Renderer>, player_model: &mut PlayerModel) {
         // TODO: Remove black shadow and add dark, transparent box around name
         let width = state.width;
         // Center align text
-        for vert in &mut state.text {
+        /*for vert in &mut state.text {
             vert.x += width * 0.5;
             vert.r = 64;
             vert.g = 64;
             vert.b = 64;
         }
-        name_verts.extend_from_slice(&state.text);
+        name_verts.extend_from_slice(&state.text);*/
+let solid = Renderer::get_texture(&renderer.get_textures(), "leafish:solid");
+    let vert_id = state.text.first().map_or(0, |v| v.id);
+
+    let pad_x = 0.;//0.05;
+    let pad_y = 0.;//0.02;
+    let box_z = 0.;//0.06;
+    let x0 = -(width * 0.5) - pad_x;
+    let x1 =  (width * 0.5) + pad_x;
+    let y0 = -pad_y;
+    let y1 = state.y_scale + pad_y;
+
+    let make_box_vert = |x, y| render::model::Vertex {
+        x, y, z: box_z,
+        texture: solid.clone(),
+        texture_x: 0.0,
+        texture_y: 0.0,
+        r: 0, g: 0, b: 0, a: 160,
+        id: vert_id,
+    };
+
+    name_verts.extend_from_slice(&[
+        make_box_vert(x0, y0), make_box_vert(x1, y0), make_box_vert(x0, y1), make_box_vert(x1, y1),
+    ]);
+
         for vert in &mut state.text {
-            vert.x -= 0.01;
-            vert.y -= 0.01;
-            vert.z -= 0.05;
+            vert.x += width * 0.5;
             vert.r = 255;
             vert.g = 255;
             vert.b = 255;

--- a/src/entity/player.rs
+++ b/src/entity/player.rs
@@ -463,42 +463,37 @@ fn add_player(renderer: Arc<Renderer>, player_model: &mut PlayerModel) {
             x_scale: 0.01,
         };
         state.build(&player_model.display_name, Some(format::Color::Black));
-        // TODO: Remove black shadow and add dark, transparent box around name
-        let width = state.width;
-        // Center align text
-        /*for vert in &mut state.text {
-            vert.x += width * 0.5;
-            vert.r = 64;
-            vert.g = 64;
-            vert.b = 64;
-        }
-        name_verts.extend_from_slice(&state.text);*/
-let solid = Renderer::get_texture(&renderer.get_textures(), "leafish:solid");
-    let vert_id = state.text.first().map_or(0, |v| v.id);
+        
+        let solid = Renderer::get_texture(&renderer.get_textures(), "leafish:solid");
+        let vert_id = state.text.first().map_or(0, |v| v.id);
+        let make_box_vert = |x, y| render::model::Vertex {
+            x,
+            y,
+            z: -0.0374,
+            texture: solid.clone(),
+            texture_x: 0.0,
+            texture_y: 0.0,
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 160,
+            id: vert_id,
+        };
 
-    let pad_x = 0.;//0.05;
-    let pad_y = 0.;//0.02;
-    let box_z = 0.;//0.06;
-    let x0 = -(width * 0.5) - pad_x;
-    let x1 =  (width * 0.5) + pad_x;
-    let y0 = -pad_y;
-    let y1 = state.y_scale + pad_y;
-
-    let make_box_vert = |x, y| render::model::Vertex {
-        x, y, z: box_z,
-        texture: solid.clone(),
-        texture_x: 0.0,
-        texture_y: 0.0,
-        r: 0, g: 0, b: 0, a: 160,
-        id: vert_id,
-    };
-
-    name_verts.extend_from_slice(&[
-        make_box_vert(x0, y0), make_box_vert(x1, y0), make_box_vert(x0, y1), make_box_vert(x1, y1),
-    ]);
+        let x0 = -(state.width * 0.5) - 0.04;
+        let x1 = (state.width * 0.5) + 0.04;
+        let y0 = 0.1;
+        let y1 = 0.32;
+        name_verts.extend_from_slice(&[
+            make_box_vert(x0, y0),
+            make_box_vert(x1, y0),
+            make_box_vert(x0, y1),
+            make_box_vert(x1, y1),
+        ]);
 
         for vert in &mut state.text {
-            vert.x += width * 0.5;
+            println!("{}", vert.z);
+            vert.x += state.width * 0.5;
             vert.r = 255;
             vert.g = 255;
             vert.b = 255;


### PR DESCRIPTION
Nametags now look like a billboard like real Minecraft, instead of rotating to look at the player.

Also replaced text shadow with a transparent black box.

Before:
<img width="859" height="488" alt="Screenshot 2026-03-20 051719" src="https://github.com/user-attachments/assets/c60f09c7-ef50-4319-a5ef-c3d9e494cc62" />

After:
<img width="858" height="490" alt="Screenshot 2026-03-20 050920" src="https://github.com/user-attachments/assets/6286e6d9-7ee8-4cfb-b770-963fb8be619f" />

(yeah i intended to do this like [a year ago](https://github.com/Lea-fish/Leafish/pull/358#issuecomment-2581060263) but here we are)